### PR TITLE
delete stubdom files only

### DIFF
--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -292,8 +292,11 @@ package_xen() {
 	rm -r "${pkgdir}/usr/share/doc"
 	rm -r "${pkgdir}/usr/share/man"
 
-	# remove potential stubdom files
-	rm -r "${pkgdir}/usr/lib/xen/boot"
+	# remove stubdom files
+        rm -f "${pkgdir}/usr/lib/xen/boot/vtpmmgr-stubdom.gz" \
+                "${pkgdir}/usr/lib/xen/boot/vtpm-stubdom.gz" \
+                "${pkgdir}/usr/lib/xen/boot/xenstorepvh-stubdom.gz" \
+                "${pkgdir}/usr/lib/xen/boot/xenstore-stubdom.gz"
 
 	# remove qemu
 	if [ "${_build_qemu}" == "true" ]; then


### PR DESCRIPTION
To be able to start HVM type DomUs, we need the hvmloader, which is located in the /usr/lib/xen/boot directory after the build.
So please do not remove the whole directory!
By default, four stubdom's are built. Delete only these files and leave the rest of the directory untouched.

