### PR TITLE
Enhance UEFI compatibility with Xen

### DIFF
--- a/xen/0201-EFI-early-Add-noexit-to-inhibit-calling-ExitBootServ.patch
+++ b/xen/0201-EFI-early-Add-noexit-to-inhibit-calling-ExitBootServ.patch
@@ -1,0 +1,105 @@
+From 097d3f0c0c735cd3fee4bcbb707cbccb4fd0770b Mon Sep 17 00:00:00 2001
+From: Konrad Rzeszutek Wilk <konrad@xxxxxxxxxx>
+Date: Fri, 24 Apr 2015 16:47:18 -0400
+Subject: [PATCH 01/26] EFI/early: Add /noexit to inhibit calling
+ ExitBootServices
+
+The '/noexitboot' parameter will inhibit Xen in calling ExitBootServices.
+
+That helps with some platforms with GetNextVariableName which
+cannot deal running in 1-1 mode and having BootSevices being disabled.
+
+Signed-off-by: Konrad Rzeszutek Wilk <konrad.wilk@xxxxxxxxxx>
+Ported to Xen 4.7.0
+Signed-off-by: Marcus of Wetware Labs <marcus@wetwa.re>
+---
+ xen/arch/x86/efi/efi-boot.h |  2 +-
+ xen/common/efi/boot.c       | 16 +++++++++++-----
+ 2 files changed, 12 insertions(+), 6 deletions(-)
+
+diff --git a/xen/arch/x86/efi/efi-boot.h b/xen/arch/x86/efi/efi-boot.h
+index e82ac9daa7ad..2221cdec681a 100644
+--- a/xen/arch/x86/efi/efi-boot.h
++++ b/xen/arch/x86/efi/efi-boot.h
+@@ -816,7 +816,7 @@ void __init efi_multiboot2(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable
+ 
+     efi_relocate_esrt(SystemTable);
+ 
+-    efi_exit_boot(ImageHandle, SystemTable);
++    efi_exit_boot(ImageHandle, SystemTable, true);
+ }
+ 
+ /*
+diff --git a/xen/common/efi/boot.c b/xen/common/efi/boot.c
+index db0340c8e262..d78a315e56e0 100644
+--- a/xen/common/efi/boot.c
++++ b/xen/common/efi/boot.c
+@@ -145,7 +145,7 @@ static void efi_tables(void);
+ static void setup_efi_pci(void);
+ static void efi_variables(void);
+ static void efi_set_gop_mode(EFI_GRAPHICS_OUTPUT_PROTOCOL *gop, UINTN gop_mode);
+-static void efi_exit_boot(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable);
++static void efi_exit_boot(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable, bool exit_boot_services);
+ 
+ static const EFI_BOOT_SERVICES *__initdata efi_bs;
+ static UINT32 __initdata efi_bs_revision;
+@@ -1175,7 +1175,7 @@ static void __init efi_relocate_esrt(EFI_SYSTEM_TABLE *SystemTable)
+ #define INVALID_VIRTUAL_ADDRESS (0xBAAADUL << \
+                                  (EFI_PAGE_SHIFT + BITS_PER_LONG - 32))
+ 
+-static void __init efi_exit_boot(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
++static void __init efi_exit_boot(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable, bool exit_boot_services)
+ {
+     EFI_STATUS status;
+     UINTN info_size = 0, map_key;
+@@ -1206,8 +1206,11 @@ static void __init efi_exit_boot(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *Syste
+ 
+         efi_arch_pre_exit_boot();
+ 
+-        status = SystemTable->BootServices->ExitBootServices(ImageHandle,
++        if (exit_boot_services)
++            status = SystemTable->BootServices->ExitBootServices(ImageHandle,
+                                                              map_key);
++        else
++            status = 0;
+         efi_bs = NULL;
+         if ( status != EFI_INVALID_PARAMETER || retry )
+             break;
+@@ -1262,7 +1265,7 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
+     EFI_SHIM_LOCK_PROTOCOL *shim_lock;
+     EFI_GRAPHICS_OUTPUT_PROTOCOL *gop = NULL;
+     union string section = { NULL }, name;
+-    bool base_video = false;
++    bool base_video = false, exit_boot_services = true;
+     const char *option_str;
+     bool use_cfg_file;
+     int dt_modules_found;
+@@ -1312,6 +1315,8 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
+                     base_video = true;
+                 else if ( wstrcmp(ptr + 1, L"mapbs") == 0 )
+                     map_bs = true;
++                else if ( wstrcmp(ptr + 1, L"noexitboot") == 0 )
++                    exit_boot_services = false;
+                 else if ( wstrncmp(ptr + 1, L"cfg=", 4) == 0 )
+                     cfg_file_name = ptr + 5;
+                 else if ( i + 1 < argc && wstrcmp(ptr + 1, L"cfg") == 0 )
+@@ -1322,6 +1327,7 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
+                     PrintStr(L"Xen EFI Loader options:\r\n");
+                     PrintStr(L"-basevideo   retain current video mode\r\n");
+                     PrintStr(L"-mapbs       map EfiBootServices{Code,Data}\r\n");
++                    PrintStr(L"-noexitboot  Do not call ExitBootServices\r\n");
+                     PrintStr(L"-cfg=<file>  specify configuration file\r\n");
+                     PrintStr(L"-help, -?    display this help\r\n");
+                     blexit(NULL);
+@@ -1539,7 +1545,7 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
+ 
+     efi_relocate_esrt(SystemTable);
+ 
+-    efi_exit_boot(ImageHandle, SystemTable);
++    efi_exit_boot(ImageHandle, SystemTable, exit_boot_services);
+ 
+     efi_arch_post_exit_boot(); /* Doesn't return. */
+ }
+-- 
+2.37.3
+

--- a/xen/0202-efi-Ensure-incorrectly-typed-runtime-services-get-ma.patch
+++ b/xen/0202-efi-Ensure-incorrectly-typed-runtime-services-get-ma.patch
@@ -1,0 +1,56 @@
+From f0ec9a1726a66278249f58a46c2b4f9394b32eff Mon Sep 17 00:00:00 2001
+From: Ross Lagerwall <ross.lagerwall@citrix.com>
+Date: Fri, 20 Mar 2015 14:32:04 +0000
+Subject: [PATCH 02/26] efi: Ensure incorrectly typed runtime services get
+ mapped
+
+Some firmware implementations do not correctly mark memory needed for runtime
+services, not setting the EFI_MEMORY_RUNTIME bit and giving it a type
+EfiReservedMemoryType.  Even though EfiReservedMemoryType is not supposed to be
+used by the firmware, map these regions so that runtime services work.
+
+The failing firmware implementations were:
+    Product Name: PowerEdge R720
+    Vendor: Dell Inc.
+    Version: 2.1.2
+    Release Date: 09/19/2013
+    BIOS Revision: 2.1
+
+    Product Name: PowerEdge R320
+    Vendor: Dell Inc.
+    Version: 1.5.2
+    Release Date: 03/11/2013
+    BIOS Revision: 1.5
+
+Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>
+---
+ xen/common/efi/boot.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/xen/common/efi/boot.c b/xen/common/efi/boot.c
+index d78a315e56e0..4fb755bc4e43 100644
+--- a/xen/common/efi/boot.c
++++ b/xen/common/efi/boot.c
+@@ -156,6 +156,7 @@ static SIMPLE_TEXT_OUTPUT_INTERFACE *__initdata StdErr;
+ 
+ static UINT32 __initdata mdesc_ver;
+ static bool __initdata map_bs;
++static bool __initdata map_res = true;
+ 
+ static struct file __initdata cfg;
+ static struct file __initdata kernel;
+@@ -1717,6 +1718,11 @@ void __init efi_init_memory(void)
+                 if ( !map_bs )
+                     continue;
+                 break;
++
++            case EfiReservedMemoryType:
++                if ( !map_res )
++                    continue;
++                break;
+             }
+         }
+ 
+-- 
+2.37.3
+

--- a/xen/0203-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch
+++ b/xen/0203-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch
@@ -1,0 +1,42 @@
+From 9fbad03a0bac47d127bf7a62c8c3c374e4ca950e Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Sat, 4 Jun 2016 19:13:31 +0200
+Subject: [PATCH 03/26] Add xen.cfg options for /mapbs and /noexitboot
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+On some platforms setting EFI command line parameters is unreliable.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ xen/common/efi/boot.c | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/xen/common/efi/boot.c b/xen/common/efi/boot.c
+index 4fb755bc4e43..8e880fe30c75 100644
+--- a/xen/common/efi/boot.c
++++ b/xen/common/efi/boot.c
+@@ -1470,6 +1470,18 @@ efi_start(EFI_HANDLE ImageHandle, EFI_SYSTEM_TABLE *SystemTable)
+         name.s = get_value(&cfg, section.s, "options");
+         efi_arch_handle_cmdline(argc ? *argv : NULL, options, name.s);
+ 
++        name.s = get_value(&cfg, section.s, "mapbs");
++        if ( name.s )
++        {
++            map_bs = name.s[0] == '1';
++        }
++
++        name.s = get_value(&cfg, section.s, "noexitboot");
++        if ( name.s )
++        {
++            exit_boot_services = name.s[0] == '0';
++        }
++
+         if ( !base_video )
+         {
+             name.cs = get_value(&cfg, section.s, "video");
+-- 
+2.37.3
+

--- a/xen/0608-x86-time-Don-t-use-EFI-s-GetTime-call-by-default.patch
+++ b/xen/0608-x86-time-Don-t-use-EFI-s-GetTime-call-by-default.patch
@@ -1,0 +1,52 @@
+From c79035d499bf68f29f87e47da228d956bb44f2da Mon Sep 17 00:00:00 2001
+From: Ross Lagerwall <ross.lagerwall@xxxxxxxxxx>
+Date: Tue, 1 Dec 2015 16:57:46 +0000
+Subject: [PATCH 08/26] x86/time: Don't use EFI's GetTime call by default
+
+When EFI is used, don't use EFI's GetTime() to get the time, because it
+is broken on many platforms. From Linux commit 7efe665903d0 ("rtc:
+Disable EFI rtc for x86"):
+"Disable it explicitly for x86 so that we don't give users false
+hope that this driver will work - it won't, and your machine is likely
+to crash."
+
+Signed-off-by: Ross Lagerwall <ross.lagerwall@xxxxxxxxxx>
+---
+ xen/arch/x86/time.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/xen/arch/x86/time.c b/xen/arch/x86/time.c
+index b01acd390dc1..b6938e743f3c 100644
+--- a/xen/arch/x86/time.c
++++ b/xen/arch/x86/time.c
+@@ -1180,20 +1180,25 @@ static void __get_cmos_time(struct rtc_time *rtc)
+         rtc->year += 100;
+ }
+ 
++/* EFI's GetTime() is frequently broken so don't use it by default. */
++#undef USE_EFI_GET_TIME
++
+ static unsigned long get_cmos_time(void)
+ {
+-    unsigned long res, flags;
++    unsigned long flags;
+     struct rtc_time rtc;
+     unsigned int seconds = 60;
+     static bool __read_mostly cmos_rtc_probe;
+     boolean_param("cmos-rtc-probe", cmos_rtc_probe);
+ 
++#ifdef USE_EFI_GET_TIME
+     if ( efi_enabled(EFI_RS) )
+     {
+-        res = efi_get_time();
++        unsigned long res = efi_get_time();
+         if ( res )
+             return res;
+     }
++#endif
+ 
+     if ( likely(!(acpi_gbl_FADT.boot_flags & ACPI_FADT_NO_CMOS_RTC)) )
+         cmos_rtc_probe = false;
+-- 
+2.37.3
+

--- a/xen/0613-Fix-buildid-alignment.patch
+++ b/xen/0613-Fix-buildid-alignment.patch
@@ -1,0 +1,32 @@
+From a89b0e338dda631ac254b380c27e1d6acf614418 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Wed, 16 Nov 2022 01:24:37 +0100
+Subject: [PATCH 13/26] Fix buildid alignment
+
+Fixes `objcopy: xen.efi: Data Directory size (1c) exceeds space left in
+section (8)`.
+
+Details at:
+https://lore.kernel.org/all/3TMd7J2u5gCA8ouIG_Xfcw7s5JKMG06XsDIesEB3Fi9htUJ43Lfl057wXohlpCHcszqoCmicpIlneEDO26ZqT8QfC2Y39VxBuqD3nS1j5Q4=@trmm.net/
+
+Reported by @jevank
+---
+ xen/arch/x86/xen.lds.S | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/xen/arch/x86/xen.lds.S b/xen/arch/x86/xen.lds.S
+index 8930e14fc40e..acfdf61ba307 100644
+--- a/xen/arch/x86/xen.lds.S
++++ b/xen/arch/x86/xen.lds.S
+@@ -184,6 +184,7 @@ SECTIONS
+        __note_gnu_build_id_end = .;
+   } PHDR(note) PHDR(text)
+ #elif defined(BUILD_ID_EFI)
++  . = ALIGN(32);
+   DECL_SECTION(.buildid) {
+        __note_gnu_build_id_start = .;
+        *(.buildid)
+-- 
+2.37.3
+

--- a/xen/0626-Validate-EFI-memory-descriptors.patch
+++ b/xen/0626-Validate-EFI-memory-descriptors.patch
@@ -1,0 +1,138 @@
+From a455fbeaa7bb1d383f4d471a55b6d3b739e10980 Mon Sep 17 00:00:00 2001
+Message-Id: <fac0c8e2e1328cf58f2ede6c69122bd7a96c40d3.1671487722.git.demi@invisiblethingslab.com>
+In-Reply-To: <cover.1671487722.git.demi@invisiblethingslab.com>
+References: <cover.1671487722.git.demi@invisiblethingslab.com>
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Fri, 18 Nov 2022 22:51:04 -0500
+Subject: [PATCH 1/2] Validate EFI memory descriptors
+Cc: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+
+It turns out that these can be invalid in various ways.  Based on code
+Ard Biesheuvel contributed for Linux.
+
+This could cause problems on buggy firmware, but the original behavior
+(silently processing garbage descriptors) isn't great either.
+
+Co-developed-by: Ard Biesheuvel <ardb@kernel.org>
+Signed-off-by: Ard Biesheuvel <ardb@kernel.org>
+Signed-off-by: Demi Marie Obenour <demi@invisiblethingslab.com>
+---
+ xen/arch/x86/efi/efi-boot.h |  4 +++-
+ xen/common/efi/boot.c       | 19 ++++++++++++++-----
+ xen/common/efi/efi.h        | 21 +++++++++++++++++++++
+ xen/common/efi/runtime.c    |  2 +-
+ 4 files changed, 39 insertions(+), 7 deletions(-)
+
+diff --git a/xen/arch/x86/efi/efi-boot.h b/xen/arch/x86/efi/efi-boot.h
+index 4575c6e1b7..8bf3377f4e 100644
+--- a/xen/arch/x86/efi/efi-boot.h
++++ b/xen/arch/x86/efi/efi-boot.h
+@@ -164,9 +164,11 @@ static void __init efi_arch_process_memory_map(EFI_SYSTEM_TABLE *SystemTable,
+     for ( e820_raw.nr_map = i = 0; i < map_size; i += desc_size )
+     {
+         EFI_MEMORY_DESCRIPTOR *desc = map + i;
+-        u64 len = desc->NumberOfPages << EFI_PAGE_SHIFT;
++        uint64_t len = efi_memory_descriptor_len(desc);
+         u32 type;
+ 
++        if ( len == 0 )
++            continue;
+         switch ( desc->Type )
+         {
+         case EfiBootServicesCode:
+diff --git a/xen/common/efi/boot.c b/xen/common/efi/boot.c
+index 4d07a92dc8..1843b65c8f 100644
+--- a/xen/common/efi/boot.c
++++ b/xen/common/efi/boot.c
+@@ -593,15 +593,14 @@ static UINTN __initdata esrt = EFI_INVALID_TABLE_ADDR;
+ 
+ static size_t __init get_esrt_size(const EFI_MEMORY_DESCRIPTOR *desc)
+ {
+-    size_t available_len, len;
++    UINT64 available_len, len = efi_memory_descriptor_len(desc);
+     const UINTN physical_start = desc->PhysicalStart;
+     const EFI_SYSTEM_RESOURCE_TABLE *esrt_ptr;
+ 
+-    len = desc->NumberOfPages << EFI_PAGE_SHIFT;
+     if ( esrt == EFI_INVALID_TABLE_ADDR )
+-        return 0;
++        return 0; /* invalid ESRT */
+     if ( physical_start > esrt || esrt - physical_start >= len )
+-        return 0;
++        return 0; /* ESRT not in this memory region */
+     /*
+      * The specification requires EfiBootServicesData, but also accept
+      * EfiRuntimeServicesData (for compatibility with buggy firmware)
+@@ -1701,7 +1700,7 @@ void __init efi_init_memory(void)
+     for ( i = 0; i < efi_memmap_size; i += efi_mdesc_size )
+     {
+         EFI_MEMORY_DESCRIPTOR *desc = efi_memmap + i;
+-        u64 len = desc->NumberOfPages << EFI_PAGE_SHIFT;
++        uint64_t len = efi_memory_descriptor_len(desc);
+         unsigned long smfn, emfn;
+         unsigned int prot = PAGE_HYPERVISOR_RWX;
+         paddr_t mem_base;
+@@ -1722,6 +1721,16 @@ void __init efi_init_memory(void)
+                     ROUNDUP(desc->PhysicalStart + len, PAGE_SIZE));
+         }
+ 
++        if ( len == 0 )
++        {
++            printk(XENLOG_ERR "BAD EFI MEMORY DESCRIPTOR: "
++                   "PhysicalStart=%016" PRIx64 " NumberOfPages=%016" PRIx64
++                   " type=%" PRIu32 " attr=%016" PRIx64 "\n",
++                   desc->PhysicalStart, desc->NumberOfPages,
++                   desc->Type, desc->Attribute);
++            continue;
++        }
++
+         if ( !efi_enabled(EFI_RS) )
+             continue;
+ 
+diff --git a/xen/common/efi/efi.h b/xen/common/efi/efi.h
+index c02fbb7b69..c86450eb70 100644
+--- a/xen/common/efi/efi.h
++++ b/xen/common/efi/efi.h
+@@ -51,3 +51,24 @@ void free_ebmalloc_unused_mem(void);
+ 
+ const void *pe_find_section(const void *image, const UINTN image_size,
+                             const CHAR16 *section_name, UINTN *size_out);
++
++static inline UINT64
++efi_memory_descriptor_len(const EFI_MEMORY_DESCRIPTOR *desc)
++{
++    uint64_t remaining_space, limit = 1ULL << PADDR_BITS;
++
++    BUILD_BUG_ON(PADDR_BITS >= 64 || PADDR_BITS < 32);
++
++    if ( desc->PhysicalStart & (EFI_PAGE_SIZE - 1) )
++        return 0; /* misaligned start address */
++
++    if ( desc->PhysicalStart >= limit )
++        return 0; /* physical start out of range */
++
++    remaining_space = limit - desc->PhysicalStart;
++
++    if ( desc->NumberOfPages > (remaining_space >> EFI_PAGE_SHIFT) )
++        return 0; /* too many pages */
++
++    return desc->NumberOfPages << EFI_PAGE_SHIFT;
++}
+diff --git a/xen/common/efi/runtime.c b/xen/common/efi/runtime.c
+index 5cb7504c96..1dc26b6100 100644
+--- a/xen/common/efi/runtime.c
++++ b/xen/common/efi/runtime.c
+@@ -270,7 +270,7 @@ int efi_get_info(uint32_t idx, union xenpf_efi_info *info)
+         for ( i = 0; i < efi_memmap_size; i += efi_mdesc_size )
+         {
+             EFI_MEMORY_DESCRIPTOR *desc = efi_memmap + i;
+-            u64 len = desc->NumberOfPages << EFI_PAGE_SHIFT;
++            uint64_t len = efi_memory_descriptor_len(desc);
+ 
+             if ( info->mem.addr >= desc->PhysicalStart &&
+                  info->mem.addr < desc->PhysicalStart + len )
+-- 
+Sincerely,
+Demi Marie Obenour (she/her/hers)
+Invisible Things Lab
+

--- a/xen/0630-Drop-ELF-notes-from-non-EFI-binary-too.patch
+++ b/xen/0630-Drop-ELF-notes-from-non-EFI-binary-too.patch
@@ -1,0 +1,40 @@
+From aa8b1a2c36a3fa694341fa530ffb8586c7002a90 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Mon, 13 Feb 2023 15:12:55 +0100
+Subject: [PATCH] Drop ELF notes from non-EFI binary too
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The ELF is repacked from from 64bit to 32bit. With CET-related notes,
+which use 64bit fields, this results in 32bit binary with corrupted
+notes. Drop them all (except build-id and PVH note retained
+explicitly).
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ xen/arch/x86/xen.lds.S | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/xen/arch/x86/xen.lds.S b/xen/arch/x86/xen.lds.S
+index 8930e14fc40e..f0831bd677e7 100644
+--- a/xen/arch/x86/xen.lds.S
++++ b/xen/arch/x86/xen.lds.S
+@@ -192,13 +192,6 @@ SECTIONS
+ #endif
+ #endif
+ 
+-#ifndef EFI
+-  /* Retain these just for the purpose of possible analysis tools. */
+-  DECL_SECTION(.note) {
+-       *(.note.*)
+-  } PHDR(note) PHDR(text)
+-#endif
+-
+   _erodata = .;
+ 
+   . = ALIGN(SECTION_ALIGN);
+-- 
+2.37.3
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -103,6 +103,14 @@ _patches=(
 
 # (Modified) patches pulled from down stream that are useful for our package.
 _feature_patches=(
+	# Patches taken from Qubes' patchset.
+	"0201-EFI-early-Add-noexit-to-inhibit-calling-ExitBootServ.patch"
+	"0202-efi-Ensure-incorrectly-typed-runtime-services-get-ma.patch"
+	"0203-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch"
+	"0608-x86-time-Don-t-use-EFI-s-GetTime-call-by-default.patch"
+	"0613-Fix-buildid-alignment.patch"
+	"0626-Validate-EFI-memory-descriptors.patch"
+	"0630-Drop-ELF-notes-from-non-EFI-binary-too.patch"
 )
 
 
@@ -138,6 +146,14 @@ _patch_sums=(
 )
 
 _feature_patch_sums=(
+	# Patches taken from Qubes' patchset.
+	"11e37c6f2b2d8356d4a6fea2ae452b6674eca1ac793cfedf00ae350705f34b117fe72e76c519953c0190524332c406698eb85daa96408bebcd12a497d1f61d79" # 0201-EFI-early-Add-noexit-to-inhibit-calling-ExitBootServ.patch
+	"884f7f050085b6cc1c73d7ccbb6f946447c6fb09680686238630fa8b7dc7a68045836c7f60bdf5c8d3f938ab1f3d3182e92d02e2b9f2ed1c9bbfdd76ef6d0667" # 0202-efi-Ensure-incorrectly-typed-runtime-services-get-ma.patch
+	"d252beeb794477aa5d88cd0607eabb903f89f54465a0adf47f03cb95476b605ec5136b5e8aabd91af165af887ec68eb52f7190a3c7c929076e18a5f5fd58ce15" # 0203-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch
+	"7bad18013917be286c447d43d6bca2893ecba2e9f9ea33227515d7bdd1c97bdbd27cfdc187db8d8f782f72e4c89231b9e1f7d4d08a5c33c92b30598d426cf8ce" # 0608-x86-time-Don-t-use-EFI-s-GetTime-call-by-default.patch
+	"807923061899007ea5eb08f445ae6bcf35b07e44a3b6644f4ba05513819ce72d34e1824f2316019bc1688c1e9ddaa4e6512d9940641f04e2e63e1087a527b210" # 0613-Fix-buildid-alignment.patch
+	"e2105aa4f07bc3b9cf2b39ee0dc4e72d1dc3fc99212c126ba2889d79cc07c04ed0d33a0edb405c7ab48575fe225893c1c916ae808cd94dba00a910fd94c15ee8" # 0626-Validate-EFI-memory-descriptors.patch
+	"5e7ebb5ec7ea27b236707b0c761f52a9502c540471989d28dfb577cfadd9e995c09ae6baaae52fc76cd08afba4d04f241483f6c07a501ba445ecfdaa14d0c79e" # 0630-Drop-ELF-notes-from-non-EFI-binary-too.patch
 )
 
 

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -101,6 +101,11 @@ _patches=(
 )
 
 
+# (Modified) patches pulled from down stream that are useful for our package.
+_feature_patches=(
+)
+
+
 # Sources required for building stubdom
 _stubdom_source=(
 	"vtpm-gcc12-fixes.patch"  # based on above patch
@@ -132,6 +137,9 @@ _sha512sums=(
 _patch_sums=(
 )
 
+_feature_patch_sums=(
+)
+
 
 _stub_sums=(
 	"2397795a0a4999a6efee3d8291356673d1757bc1b34dd2015378ef6ea8800ee1317c7d9f902d82bd62ff8d451223ad51ced5e3a6d66e8e79930a7f513cc2b805" # vtpm-gcc12-fixes.patch
@@ -148,13 +156,9 @@ _stub_sums=(
 
 
 # Simplify things for makepkg
-source=( "${_source[@]}" "${_patches[@]}" )
-sha512sums=( "${_sha512sums[@]}" "${_patch_sums[@]}" )
-
-for file in "${_patches[@]}"; do
-	noextract+=( $(basename ${file}) )
-done
-
+source=( "${_source[@]}" "${_patches[@]}" "${_feature_patches[@]}" )
+sha512sums=( "${_sha512sums[@]}" "${_patch_sums[@]}" "${_feature_patch_sums[@]}" )
+noextract+=( "${_patches[@]##*/}" "${_feature_patches[@]##*/}" )
 
 # stubdom handling
 if [ "${_build_stubdom}" == "true" ]; then
@@ -182,6 +186,16 @@ fi
 prepare() {
 
 	cd "${pkgbase}"
+
+	# This is required for applying patches with git am. Assume no user is set
+	# up.
+	git config user.name user
+	git config user.email user@localhost
+
+	for patchurl in "${_feature_patches[@]}"; do
+		patch=$(basename $patchurl)
+		git am "../${patch}"
+	done
 
 	if [ "${_build_stubdom}" == "true" ]; then
 


### PR DESCRIPTION
These patches improve compatibility with UEFI enabled systems. Mainly through validating memory and being more in line with what Linux is doing. Certain calls that are currently used have a tendency to either simply not work, or even outright crash the system. These patches taken from Qubes address these issues.

We also add the `mapbs` and `noexitboot` commandline options to Xen's EFI interface and configuration file.

Refer to the attached patches for more info. 

TODO: Add documentation to the HTML docs about the `mapbs` and `noexitboot` parameters.