### PR TITLE
xen: Improve libxl backend handling stability

### DIFF
--- a/xen/0605-libxl-do-not-wait-for-backend-on-PCI-remove-when-bac.patch
+++ b/xen/0605-libxl-do-not-wait-for-backend-on-PCI-remove-when-bac.patch
@@ -1,0 +1,59 @@
+From 6f2e64671cd1dc2c82bcd8574b449ed2798b0401 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Wed, 5 Mar 2014 02:18:52 +0100
+Subject: [PATCH 05/26] libxl: do not wait for backend on PCI remove when
+ backend already closed
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Especially this is the case during domain destroy - backend and frontend
+are already closed so just remove the devices, without waiting for
+(timeout on) backend state.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_pci.c | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/tools/libs/light/libxl_pci.c b/tools/libs/light/libxl_pci.c
+index f4c4f175454d..b863da2f0d60 100644
+--- a/tools/libs/light/libxl_pci.c
++++ b/tools/libs/light/libxl_pci.c
+@@ -226,7 +226,7 @@ out:
+ static int libxl__device_pci_remove_xenstore(libxl__gc *gc, uint32_t domid, libxl_device_pci *pci)
+ {
+     libxl_ctx *ctx = libxl__gc_owner(gc);
+-    char *be_path, *num_devs_path, *num_devs, *xsdev, *tmp, *tmppath;
++    char *be_path, *num_devs_path, *num_devs, *xsdev, *tmp, *tmppath, *state_before;
+     int num, i, j;
+     xs_transaction_t t;
+ 
+@@ -237,12 +237,13 @@ static int libxl__device_pci_remove_xenstore(libxl__gc *gc, uint32_t domid, libx
+     if (!num_devs)
+         return ERROR_INVAL;
+     num = atoi(num_devs);
++    state_before = libxl__xs_read(gc, XBT_NULL, libxl__sprintf(gc, "%s/state", be_path));
+ 
+     libxl_domain_type domtype = libxl__domain_type(gc, domid);
+     if (domtype == LIBXL_DOMAIN_TYPE_INVALID)
+         return ERROR_FAIL;
+ 
+-    if (domtype == LIBXL_DOMAIN_TYPE_PV) {
++    if (domtype == LIBXL_DOMAIN_TYPE_PV && state_before && atoi(state_before) != 6) {
+         if (libxl__wait_for_backend(gc, be_path, GCSPRINTF("%d", XenbusStateConnected)) < 0) {
+             LOGD(DEBUG, domid, "pci backend at %s is not ready", be_path);
+             return ERROR_FAIL;
+@@ -264,6 +265,8 @@ static int libxl__device_pci_remove_xenstore(libxl__gc *gc, uint32_t domid, libx
+     }
+ 
+ retry_transaction:
++    if (state_before && atoi(state_before) == XenbusStateClosed)
++        goto retry_transaction2;
+     t = xs_transaction_start(ctx->xsh);
+     xs_write(ctx->xsh, t, GCSPRINTF("%s/state-%d", be_path, i), GCSPRINTF("%d", XenbusStateClosing), 1);
+     xs_write(ctx->xsh, t, GCSPRINTF("%s/state", be_path), GCSPRINTF("%d", XenbusStateReconfiguring), 1);
+-- 
+2.37.3
+

--- a/xen/0606-libxl-do-not-fail-device-removal-if-backend-domain-i.patch
+++ b/xen/0606-libxl-do-not-fail-device-removal-if-backend-domain-i.patch
@@ -1,0 +1,47 @@
+From 4a925c66fb28641aed768a9b87910e68fa516913 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Sun, 28 Jan 2018 03:46:47 +0100
+Subject: [PATCH 06/26] libxl: do not fail device removal if backend domain is
+ gone
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Backend domain may be independently destroyed - there is no
+synchronization of libxl structures (including /libxl tree) elsewhere.
+Backend might also remove the device info from its backend xenstore
+subtree on its own.
+If such situation is detected, do not fail the removal, but finish the
+cleanup on frontend side.
+This is just workaround, the real fix should watch when the device
+backend is removed (including backend domain destruction) and remove
+frontend at that time. And report such event to higher layer code, so
+for example libvirt could synchronize its state.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_device.c | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/tools/libs/light/libxl_device.c b/tools/libs/light/libxl_device.c
+index a75c21d4337c..fe559c04a218 100644
+--- a/tools/libs/light/libxl_device.c
++++ b/tools/libs/light/libxl_device.c
+@@ -1050,6 +1050,13 @@ void libxl__initiate_device_generic_remove(libxl__egc *egc,
+             goto out;
+         }
+ 
++        /* if state_path is empty, assume backend is gone (backend domain
++         * shutdown?), cleanup frontend only; rc=0 */
++        if (!state) {
++            LOG(WARN, "backend %s already removed, cleanup frontend only", be_path);
++            goto out;
++        }
++
+         rc = libxl__xs_write_checked(gc, t, online_path, "0");
+         if (rc)
+             goto out;
+-- 
+2.37.3
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -107,6 +107,8 @@ _feature_patches=(
 	"0201-EFI-early-Add-noexit-to-inhibit-calling-ExitBootServ.patch"
 	"0202-efi-Ensure-incorrectly-typed-runtime-services-get-ma.patch"
 	"0203-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch"
+	"0605-libxl-do-not-wait-for-backend-on-PCI-remove-when-bac.patch"
+	"0606-libxl-do-not-fail-device-removal-if-backend-domain-i.patch"
 	"0608-x86-time-Don-t-use-EFI-s-GetTime-call-by-default.patch"
 	"0613-Fix-buildid-alignment.patch"
 	"0626-Validate-EFI-memory-descriptors.patch"
@@ -150,6 +152,8 @@ _feature_patch_sums=(
 	"11e37c6f2b2d8356d4a6fea2ae452b6674eca1ac793cfedf00ae350705f34b117fe72e76c519953c0190524332c406698eb85daa96408bebcd12a497d1f61d79" # 0201-EFI-early-Add-noexit-to-inhibit-calling-ExitBootServ.patch
 	"884f7f050085b6cc1c73d7ccbb6f946447c6fb09680686238630fa8b7dc7a68045836c7f60bdf5c8d3f938ab1f3d3182e92d02e2b9f2ed1c9bbfdd76ef6d0667" # 0202-efi-Ensure-incorrectly-typed-runtime-services-get-ma.patch
 	"d252beeb794477aa5d88cd0607eabb903f89f54465a0adf47f03cb95476b605ec5136b5e8aabd91af165af887ec68eb52f7190a3c7c929076e18a5f5fd58ce15" # 0203-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch
+	"0ee82e4113e9f56292c2d61b3ae157e45b293ced919658504325419c4fb3090a2ac4aa895bd33162c5d2110922db99b2d2949605d009147996ec090d5984cbb8" # 0605-libxl-do-not-wait-for-backend-on-PCI-remove-when-bac.patch
+	"fff225a84d8b135fcb46445b3a26b82fed6b4826d72d658e890a6ecb825ce3513c9ff75cd84e15d09b3782e4a02ab43a0f5ba189ec4a297a1725fe1913e0e35b" # 0606-libxl-do-not-fail-device-removal-if-backend-domain-i.patch
 	"7bad18013917be286c447d43d6bca2893ecba2e9f9ea33227515d7bdd1c97bdbd27cfdc187db8d8f782f72e4c89231b9e1f7d4d08a5c33c92b30598d426cf8ce" # 0608-x86-time-Don-t-use-EFI-s-GetTime-call-by-default.patch
 	"807923061899007ea5eb08f445ae6bcf35b07e44a3b6644f4ba05513819ce72d34e1824f2316019bc1688c1e9ddaa4e6512d9940641f04e2e63e1087a527b210" # 0613-Fix-buildid-alignment.patch
 	"e2105aa4f07bc3b9cf2b39ee0dc4e72d1dc3fc99212c126ba2889d79cc07c04ed0d33a0edb405c7ab48575fe225893c1c916ae808cd94dba00a910fd94c15ee8" # 0626-Validate-EFI-memory-descriptors.patch


### PR DESCRIPTION
Stops libxl from waiting on the backend to remove the PCI when it's already closed.  
Stops libxl from failing device removal if the backend domain is gone.