### PR TITLE
xen: Fix stubdom from sporadically failing to add PCI devices

### DIFF
--- a/xen/0607-libvchan-use-xengntshr_unshare-instead-of-munmap-dir.patch
+++ b/xen/0607-libvchan-use-xengntshr_unshare-instead-of-munmap-dir.patch
@@ -1,0 +1,32 @@
+From ff801e2db2cf73bbb4f4ee6eafeb4c5b5686ae96 Mon Sep 17 00:00:00 2001
+From: Marek Marczykowski <marmarek@invisiblethingslab.com>
+Date: Fri, 26 Apr 2013 14:40:05 +0200
+Subject: [PATCH 07/26] libvchan: use xengntshr_unshare instead of munmap
+ directly
+
+Signed-off-by: Marek Marczykowski <marmarek@invisiblethingslab.com>
+---
+ tools/libs/vchan/io.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/tools/libs/vchan/io.c b/tools/libs/vchan/io.c
+index 1f201ad554f2..9339e97c79d0 100644
+--- a/tools/libs/vchan/io.c
++++ b/tools/libs/vchan/io.c
+@@ -362,9 +362,11 @@ void libxenvchan_close(struct libxenvchan *ctrl)
+ 	if (!ctrl)
+ 		return;
+ 	if (ctrl->read.order >= PAGE_SHIFT)
+-		munmap(ctrl->read.buffer, 1 << ctrl->read.order);
++		xengntshr_unshare(ctrl->gntshr, ctrl->read.buffer,
++				1 << (ctrl->read.order - PAGE_SHIFT));
+ 	if (ctrl->write.order >= PAGE_SHIFT)
+-		munmap(ctrl->write.buffer, 1 << ctrl->write.order);
++		xengntshr_unshare(ctrl->gntshr, ctrl->write.buffer,
++				1 << (ctrl->write.order - PAGE_SHIFT));
+ 	if (ctrl->ring) {
+ 		if (ctrl->is_server) {
+ 			ctrl->ring->srv_live = 0;
+-- 
+2.37.3
+

--- a/xen/0614-vchan-socket-proxy-add-reconnect-marker-support.patch
+++ b/xen/0614-vchan-socket-proxy-add-reconnect-marker-support.patch
@@ -1,0 +1,146 @@
+From d02ba25ba05722588c7389d9bf91e407095521b3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Sat, 3 Sep 2022 03:48:42 +0200
+Subject: [PATCH 14/26] vchan-socket-proxy: add reconnect marker support
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When vchan client reconnect quickly, the server may not notice it. This
+means, it won't reconnect the UNIX socket either. For QMP, it will
+prevent the client to see the QMP protocol handshake, and the
+communication will timeout.
+Solve the issue by sending in-band connect marker. Whenever server sees
+one (elsewhere than the first byte in the connection), handle it as a
+client had reconnected. The marker is a one byte, and the user need to
+choose something that doesn't appear in the data stream elsewhere.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/vchan/vchan-socket-proxy.c | 51 +++++++++++++++++++++++++++++++-
+ 1 file changed, 50 insertions(+), 1 deletion(-)
+
+diff --git a/tools/vchan/vchan-socket-proxy.c b/tools/vchan/vchan-socket-proxy.c
+index e1d959c6d15c..1e7defe9bae7 100644
+--- a/tools/vchan/vchan-socket-proxy.c
++++ b/tools/vchan/vchan-socket-proxy.c
+@@ -31,6 +31,7 @@
+  * One client is served at a time, clients needs to coordinate this themselves.
+  */
+ 
++#define _GNU_SOURCE
+ #include <stdlib.h>
+ #include <stdio.h>
+ #include <string.h>
+@@ -54,6 +55,9 @@ static void usage(char** argv)
+         "\t-m, --mode=client|server - vchan connection mode (client by default)\n"
+         "\t-s, --state-path=path - xenstore path where write \"running\" to \n"
+         "\t                        at startup\n"
++        "\t-r, --reconnect-marker=value - send(client)/expect(server) a\n"
++        "\t                single-byte marker to detect quick reconnects and\n"
++        "\t                force reconnecting UNIX socket\n"
+         "\t-v, --verbose - verbose logging\n"
+         "\n"
+         "client: client of a vchan connection, fourth parameter can be:\n"
+@@ -61,7 +65,7 @@ static void usage(char** argv)
+         "\t             whenever new connection is accepted;\n"
+         "\t             handle multiple _subsequent_ connections, until terminated\n"
+         "\n"
+-        "\tfile-no:     except open FD of a socket in listen mode;\n"
++        "\tfile-no:     expect open FD of a socket in listen mode;\n"
+         "\t             otherwise similar to socket-path\n"
+         "\n"
+         "\t-:           open vchan connection immediately and pass the data\n"
+@@ -88,6 +92,7 @@ char outbuf[BUFSIZE];
+ int insiz = 0;
+ int outsiz = 0;
+ int verbose = 0;
++int reconnect_marker_value = -1;
+ 
+ struct vchan_proxy_state {
+     struct libxenvchan *ctrl;
+@@ -291,6 +296,7 @@ int data_loop(struct vchan_proxy_state *state)
+     int ret;
+     int libxenvchan_fd;
+     int max_fd;
++    bool just_connected = true;
+ 
+     libxenvchan_fd = libxenvchan_fd_for_select(state->ctrl);
+     for (;;) {
+@@ -368,8 +374,33 @@ int data_loop(struct vchan_proxy_state *state)
+                 exit(1);
+             if (verbose)
+                 fprintf(stderr, "from-vchan: %.*s\n", ret, outbuf + outsiz);
++            if (reconnect_marker_value != -1) {
++                char *reconnect_found =
++                    memrchr(outbuf + outsiz, reconnect_marker_value, ret);
++                if (just_connected && reconnect_found == outbuf + outsiz) {
++                    /* skip reconnect marker at the very first byte of the data
++                     * stream */
++                    memmove(outbuf + outsiz, outbuf + outsiz + 1, ret - 1);
++                    ret -= 1;
++                } else if (reconnect_found) {
++                    size_t newsiz = outbuf + outsiz + ret - reconnect_found - 1;
++                    if (verbose)
++                        fprintf(stderr, "reconnect marker found\n");
++                    /* discard everything before and including the reconnect
++                     * marker */
++                    memmove(outbuf, reconnect_found + 1, newsiz);
++                    outsiz = newsiz;
++                    /* then handle it as the client had just disconnected */
++                    close(state->output_fd);
++                    state->output_fd = -1;
++                    close(state->input_fd);
++                    state->input_fd = -1;
++                    return 0;
++                }
++            }
+             outsiz += ret;
+             socket_wr(state->output_fd);
++            just_connected = false;
+         }
+     }
+     return 0;
+@@ -385,6 +416,7 @@ static struct option options[] = {
+     { "mode",       required_argument, NULL, 'm' },
+     { "verbose",          no_argument, NULL, 'v' },
+     { "state-path", required_argument, NULL, 's' },
++    { "reconnect-marker", required_argument, NULL, 'r' },
+     { }
+ };
+ 
+@@ -421,6 +453,14 @@ int main(int argc, char **argv)
+             case 's':
+                 state_path = optarg;
+                 break;
++            case 'r':
++                reconnect_marker_value = atoi(optarg);
++                if (reconnect_marker_value < 0 || reconnect_marker_value > 255) {
++                    fprintf(stderr, "invalid argument for --reconnect-marker, "
++                                    "must be a number between 0 and 255\n");
++                    usage(argv);
++                }
++                break;
+             case '?':
+                 usage(argv);
+         }
+@@ -509,6 +549,15 @@ int main(int argc, char **argv)
+                 ret = 1;
+                 break;
+             }
++            if (reconnect_marker_value != -1) {
++                const char marker_buf[] = { reconnect_marker_value };
++
++                if (libxenvchan_write(state.ctrl, marker_buf, sizeof(marker_buf))
++                        != sizeof(marker_buf)) {
++                    fprintf(stderr, "failed to send reconnect marker\n");
++                    break;
++                }
++            }
+             if (data_loop(&state) != 0)
+                 break;
+             /* don't reconnect if output was stdout */
+-- 
+2.37.3
+

--- a/xen/0615-tools-libxl-enable-in-band-reconnect-marker-for-stub.patch
+++ b/xen/0615-tools-libxl-enable-in-band-reconnect-marker-for-stub.patch
@@ -1,0 +1,46 @@
+From 419baf62a844182b7ce16b70dd45bc728c785a02 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Sat, 3 Sep 2022 04:31:34 +0200
+Subject: [PATCH 15/26] tools/libxl: enable in-band reconnect marker for
+ stubdom QMP proxy
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This enables stubdom reliably detect when it needs to reconnect QMP
+socket. It is critical, as otherwise QEMU will not send its handshake,
+and so libxl will timeout while waiting on one. When it happens during
+domain startup, it can result in error like this:
+
+libxl: libxl_pci.c:1772:device_pci_add_done: Domain 3:libxl__device_pci_add failed for PCI device 0:0:14.0 (rc -9)
+libxl: libxl_create.c:1904:domcreate_attach_devices: Domain 3:unable to add pci devices
+
+See vchan-socket-proxy commit message for details about this reconnect
+corner case.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_dm.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/tools/libs/light/libxl_dm.c b/tools/libs/light/libxl_dm.c
+index f5d930bb94f0..f0895f192cf8 100644
+--- a/tools/libs/light/libxl_dm.c
++++ b/tools/libs/light/libxl_dm.c
+@@ -2637,10 +2637,11 @@ static void spawn_qmp_proxy(libxl__egc *egc,
+     sdss->qmp_proxy_spawn.failure_cb = qmp_proxy_startup_failed;
+     sdss->qmp_proxy_spawn.detached_cb = qmp_proxy_detached;
+ 
+-    const int arraysize = 6;
++    const int arraysize = 7;
+     GCNEW_ARRAY(args, arraysize);
+     args[nr++] = STUBDOM_QMP_PROXY_PATH;
+     args[nr++] = GCSPRINTF("--state-path=%s", sdss->qmp_proxy_spawn.xspath);
++    args[nr++] = "--reconnect-marker=1";
+     args[nr++] = GCSPRINTF("%u", dm_domid);
+     args[nr++] = GCSPRINTF("%s/device-model/%u/qmp-vchan", dom_path, guest_domid);
+     args[nr++] = (char*)libxl__qemu_qmp_path(gc, guest_domid);
+-- 
+2.37.3
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -107,8 +107,11 @@ _feature_patches=(
 	"0201-EFI-early-Add-noexit-to-inhibit-calling-ExitBootServ.patch"
 	"0202-efi-Ensure-incorrectly-typed-runtime-services-get-ma.patch"
 	"0203-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch"
+	"0607-libvchan-use-xengntshr_unshare-instead-of-munmap-dir.patch"
 	"0608-x86-time-Don-t-use-EFI-s-GetTime-call-by-default.patch"
 	"0613-Fix-buildid-alignment.patch"
+	"0614-vchan-socket-proxy-add-reconnect-marker-support.patch"
+	"0615-tools-libxl-enable-in-band-reconnect-marker-for-stub.patch"
 	"0626-Validate-EFI-memory-descriptors.patch"
 	"0630-Drop-ELF-notes-from-non-EFI-binary-too.patch"
 )
@@ -150,8 +153,11 @@ _feature_patch_sums=(
 	"11e37c6f2b2d8356d4a6fea2ae452b6674eca1ac793cfedf00ae350705f34b117fe72e76c519953c0190524332c406698eb85daa96408bebcd12a497d1f61d79" # 0201-EFI-early-Add-noexit-to-inhibit-calling-ExitBootServ.patch
 	"884f7f050085b6cc1c73d7ccbb6f946447c6fb09680686238630fa8b7dc7a68045836c7f60bdf5c8d3f938ab1f3d3182e92d02e2b9f2ed1c9bbfdd76ef6d0667" # 0202-efi-Ensure-incorrectly-typed-runtime-services-get-ma.patch
 	"d252beeb794477aa5d88cd0607eabb903f89f54465a0adf47f03cb95476b605ec5136b5e8aabd91af165af887ec68eb52f7190a3c7c929076e18a5f5fd58ce15" # 0203-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch
+	"c7548bc76b6f08e71a2df3083255e522a993812dc3568823a443b76db34b63625f65eb54837759ba0ce5d08a5aca10cad59c38e9fe4953ffbafaa5ce81ac1a55" # 0607-libvchan-use-xengntshr_unshare-instead-of-munmap-dir.patch
 	"7bad18013917be286c447d43d6bca2893ecba2e9f9ea33227515d7bdd1c97bdbd27cfdc187db8d8f782f72e4c89231b9e1f7d4d08a5c33c92b30598d426cf8ce" # 0608-x86-time-Don-t-use-EFI-s-GetTime-call-by-default.patch
 	"807923061899007ea5eb08f445ae6bcf35b07e44a3b6644f4ba05513819ce72d34e1824f2316019bc1688c1e9ddaa4e6512d9940641f04e2e63e1087a527b210" # 0613-Fix-buildid-alignment.patch
+	"9e8e2af77de1f2154078ffa2f55049230a7c38ffc14ba1859bb08d1b34a81c21d18a6ac7b4cc65bdabc56ee8b84ba5a3dbe4451fe79a9049223bda6c6b1fbe74" # 0614-vchan-socket-proxy-add-reconnect-marker-support.patch
+	"205e4b6fd3d94fae07079a47f9fcaa92cb0a97beba4fa64b3e5e4c00d50aa20689ff4c6226f65a81547217d7f0824c38afb204e451ac7360d028ec3cbc140942" # 0615-tools-libxl-enable-in-band-reconnect-marker-for-stub.patch
 	"e2105aa4f07bc3b9cf2b39ee0dc4e72d1dc3fc99212c126ba2889d79cc07c04ed0d33a0edb405c7ab48575fe225893c1c916ae808cd94dba00a910fd94c15ee8" # 0626-Validate-EFI-memory-descriptors.patch
 	"5e7ebb5ec7ea27b236707b0c761f52a9502c540471989d28dfb577cfadd9e995c09ae6baaae52fc76cd08afba4d04f241483f6c07a501ba445ecfdaa14d0c79e" # 0630-Drop-ELF-notes-from-non-EFI-binary-too.patch
 )


### PR DESCRIPTION
These patches enable stubdomains to reliably detect when they need to reconnect to the QEMU QMP socket.  
This prevents PCI device add from failing when using stubdomains.