### PR TITLE
xen: Automatically enable gfx_passthru if IGD is assigned

### DIFF
--- a/xen/0609-libxl-automatically-enable-gfx_passthru-if-IGD-is-as.patch
+++ b/xen/0609-libxl-automatically-enable-gfx_passthru-if-IGD-is-as.patch
@@ -1,0 +1,140 @@
+From 59bb85dbfbc7d079afcc6c80255f05e951a26b54 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Sat, 6 Jun 2020 05:02:33 +0200
+Subject: [PATCH 09/26] libxl: automatically enable gfx_passthru if IGD is
+ assigned
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+The gfx_passthru option needs to be enabled whenever IGD is assigned,
+otherwise qemu refuses to start. Similarly, if gfx_passthru is enabled,
+IGD needs to be assigned, otherwise libxl refuses to start the guest.
+This means the gfx_passthru is fully redundant to assigning IGD (besides
+enabling various non-bootable configurations).
+Change the default value to follow IGD assignment state. For that, use
+existing libxl__detect_gfx_passthru_kind (move from libxl_dm.c to
+libxl_create.c).
+
+While the option is designed with various GFX in mind, only IGD ever got
+a special treatment. PCI passthrough of other GFX devices (some AMD and
+Nvidia at least) works just fine without setting gfx_passthru at all.
+
+This change simplifies configuration, but also fixes IGD passthrough
+when using libvirt (which doesn't expose gfx_passthru option).
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ docs/man/xl.cfg.5.pod.in        |  3 +++
+ tools/libs/light/libxl_create.c | 27 ++++++++++++++++++++++++++-
+ tools/libs/light/libxl_dm.c     | 20 +-------------------
+ 3 files changed, 30 insertions(+), 20 deletions(-)
+
+diff --git a/docs/man/xl.cfg.5.pod.in b/docs/man/xl.cfg.5.pod.in
+index 31e58b73b0c9..77ca4e9510a5 100644
+--- a/docs/man/xl.cfg.5.pod.in
++++ b/docs/man/xl.cfg.5.pod.in
+@@ -1215,6 +1215,9 @@ Intel Graphics Device.
+ 
+ =back
+ 
++By default, this option is enabled if Intel Graphics Device is assigned to the
++VM.
++
+ Note that some graphics cards (AMD/ATI cards, for example) do not
+ necessarily require the B<gfx_passthru> option, so you can use the normal Xen
+ PCI passthrough to assign the graphics card as a secondary graphics
+diff --git a/tools/libs/light/libxl_create.c b/tools/libs/light/libxl_create.c
+index ed7da5f9cdc8..e23d3c866feb 100644
+--- a/tools/libs/light/libxl_create.c
++++ b/tools/libs/light/libxl_create.c
+@@ -71,6 +71,22 @@ void libxl__rdm_setdefault(libxl__gc *gc, libxl_domain_build_info *b_info)
+                             LIBXL_RDM_MEM_BOUNDARY_MEMKB_DEFAULT;
+ }
+ 
++static enum libxl_gfx_passthru_kind
++libxl__detect_gfx_passthru_kind(libxl__gc *gc,
++                                const libxl_domain_config *guest_config)
++{
++    const libxl_domain_build_info *b_info = &guest_config->b_info;
++
++    if (b_info->u.hvm.gfx_passthru_kind != LIBXL_GFX_PASSTHRU_KIND_DEFAULT)
++        return b_info->u.hvm.gfx_passthru_kind;
++
++    if (libxl__is_igd_vga_passthru(gc, guest_config)) {
++        return LIBXL_GFX_PASSTHRU_KIND_IGD;
++    }
++
++    return LIBXL_GFX_PASSTHRU_KIND_DEFAULT;
++}
++
+ int libxl__domain_build_info_setdefault(libxl__gc *gc,
+                                         libxl_domain_build_info *b_info)
+ {
+@@ -423,7 +439,8 @@ int libxl__domain_build_info_setdefault(libxl__gc *gc,
+ 
+         libxl_defbool_setdefault(&b_info->u.hvm.nographic, false);
+ 
+-        libxl_defbool_setdefault(&b_info->u.hvm.gfx_passthru, false);
++        libxl_defbool_setdefault(&b_info->u.hvm.gfx_passthru,
++                b_info->u.hvm.gfx_passthru_kind != LIBXL_GFX_PASSTHRU_KIND_DEFAULT);
+ 
+         libxl__rdm_setdefault(gc, b_info);
+         break;
+@@ -1237,6 +1254,14 @@ int libxl__domain_config_setdefault(libxl__gc *gc,
+             ? libxl__get_required_iommu_memory(d_config->b_info.max_memkb)
+             : 0;
+ 
++    if (d_config->b_info.type == LIBXL_DOMAIN_TYPE_HVM) {
++        if (d_config->b_info.u.hvm.gfx_passthru_kind == LIBXL_GFX_PASSTHRU_KIND_DEFAULT) {
++            /* this may also keep LIBXL_GFX_PASSTHRU_KIND_DEFAULT */
++            d_config->b_info.u.hvm.gfx_passthru_kind =
++                libxl__detect_gfx_passthru_kind(gc, d_config);
++        }
++    }
++
+     ret = libxl__domain_build_info_setdefault(gc, &d_config->b_info);
+     if (ret) {
+         LOGD(ERROR, domid, "Unable to set domain build info defaults");
+diff --git a/tools/libs/light/libxl_dm.c b/tools/libs/light/libxl_dm.c
+index fc264a3a13a6..98b900bd7b9d 100644
+--- a/tools/libs/light/libxl_dm.c
++++ b/tools/libs/light/libxl_dm.c
+@@ -996,22 +996,6 @@ static char *dm_spice_options(libxl__gc *gc,
+     return opt;
+ }
+ 
+-static enum libxl_gfx_passthru_kind
+-libxl__detect_gfx_passthru_kind(libxl__gc *gc,
+-                                const libxl_domain_config *guest_config)
+-{
+-    const libxl_domain_build_info *b_info = &guest_config->b_info;
+-
+-    if (b_info->u.hvm.gfx_passthru_kind != LIBXL_GFX_PASSTHRU_KIND_DEFAULT)
+-        return b_info->u.hvm.gfx_passthru_kind;
+-
+-    if (libxl__is_igd_vga_passthru(gc, guest_config)) {
+-        return LIBXL_GFX_PASSTHRU_KIND_IGD;
+-    }
+-
+-    return LIBXL_GFX_PASSTHRU_KIND_DEFAULT;
+-}
+-
+ /* colo mode */
+ enum {
+     LIBXL__COLO_NONE = 0,
+@@ -1832,9 +1816,7 @@ static int libxl__build_device_model_args_new(libxl__gc *gc,
+         }
+ 
+         if (libxl_defbool_val(b_info->u.hvm.gfx_passthru)) {
+-            enum libxl_gfx_passthru_kind gfx_passthru_kind =
+-                            libxl__detect_gfx_passthru_kind(gc, guest_config);
+-            switch (gfx_passthru_kind) {
++            switch (b_info->u.hvm.gfx_passthru_kind) {
+             case LIBXL_GFX_PASSTHRU_KIND_IGD:
+                 machinearg = GCSPRINTF("%s,igd-passthru=on", machinearg);
+                 break;
+-- 
+2.37.3
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -108,6 +108,7 @@ _feature_patches=(
 	"0202-efi-Ensure-incorrectly-typed-runtime-services-get-ma.patch"
 	"0203-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch"
 	"0608-x86-time-Don-t-use-EFI-s-GetTime-call-by-default.patch"
+	"0609-libxl-automatically-enable-gfx_passthru-if-IGD-is-as.patch"
 	"0613-Fix-buildid-alignment.patch"
 	"0626-Validate-EFI-memory-descriptors.patch"
 	"0630-Drop-ELF-notes-from-non-EFI-binary-too.patch"
@@ -151,6 +152,7 @@ _feature_patch_sums=(
 	"884f7f050085b6cc1c73d7ccbb6f946447c6fb09680686238630fa8b7dc7a68045836c7f60bdf5c8d3f938ab1f3d3182e92d02e2b9f2ed1c9bbfdd76ef6d0667" # 0202-efi-Ensure-incorrectly-typed-runtime-services-get-ma.patch
 	"d252beeb794477aa5d88cd0607eabb903f89f54465a0adf47f03cb95476b605ec5136b5e8aabd91af165af887ec68eb52f7190a3c7c929076e18a5f5fd58ce15" # 0203-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch
 	"7bad18013917be286c447d43d6bca2893ecba2e9f9ea33227515d7bdd1c97bdbd27cfdc187db8d8f782f72e4c89231b9e1f7d4d08a5c33c92b30598d426cf8ce" # 0608-x86-time-Don-t-use-EFI-s-GetTime-call-by-default.patch
+	"c83af1cdf296f05b7deef7fdb6ae4c44075c2c92bf1a0703f4963646cd252d0490171705573b1b41c9416ea4e53a21f02573d6511240e763b0f25f3e9e63211e" # 0609-libxl-automatically-enable-gfx_passthru-if-IGD-is-as.patch
 	"807923061899007ea5eb08f445ae6bcf35b07e44a3b6644f4ba05513819ce72d34e1824f2316019bc1688c1e9ddaa4e6512d9940641f04e2e63e1087a527b210" # 0613-Fix-buildid-alignment.patch
 	"e2105aa4f07bc3b9cf2b39ee0dc4e72d1dc3fc99212c126ba2889d79cc07c04ed0d33a0edb405c7ab48575fe225893c1c916ae808cd94dba00a910fd94c15ee8" # 0626-Validate-EFI-memory-descriptors.patch
 	"5e7ebb5ec7ea27b236707b0c761f52a9502c540471989d28dfb577cfadd9e995c09ae6baaae52fc76cd08afba4d04f241483f6c07a501ba445ecfdaa14d0c79e" # 0630-Drop-ELF-notes-from-non-EFI-binary-too.patch


### PR DESCRIPTION
If an Intel Graphics Device (IGD) is passed through it requires gfx_passthrough to be set while making the VM.  
If the option is not specified qemu will refuse to start. So to stop qemu from complaining and having users be confused about why their VM won't start, specify this option when we detect that an IGD is being passed through to the VM. This is not required for other graphics devices, such as NVIDIA GPUs.

This change also fixes IGD passthrough when using libvirt, which doesn't expose the `gfx_passthru` option.