### PR TITLE
xen: Do not require filling backend domid to remove a device

### DIFF
--- a/xen/0611-libxl-do-not-require-filling-backend_domid-to-remove.patch
+++ b/xen/0611-libxl-do-not-require-filling-backend_domid-to-remove.patch
@@ -1,0 +1,99 @@
+From f2c696a0d70e8fadd25a90bbd7e73af3fcd158ae Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Mon, 8 Nov 2021 03:50:35 +0100
+Subject: [PATCH 11/26] libxl: do not require filling backend_domid to remove
+ device
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Existing device can be unambiguously identified by (domid, devtype,
+devid), do not require backend_domid (or _name) to be filled. This
+especially helps detaching a device - which with not filled (or invalid)
+backend_domid would seemingly succeed, while in fact the backend
+wouldn't be cleaned up.
+
+Try to fill the backend_domid only if not explicitly given (left as 0,
+as libxl_device_disk_init() does). This allows the function to still
+work outside the toolstack domain - specifically in the backend domain
+as part of the xendriverdomain service.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_device.c   | 32 ++++++++++++++++++++++++++++++-
+ tools/libs/light/libxl_internal.h |  1 +
+ 2 files changed, 32 insertions(+), 1 deletion(-)
+
+diff --git a/tools/libs/light/libxl_device.c b/tools/libs/light/libxl_device.c
+index fe559c04a218..90bf4bed3422 100644
+--- a/tools/libs/light/libxl_device.c
++++ b/tools/libs/light/libxl_device.c
+@@ -75,6 +75,25 @@ char *libxl__device_libxl_path(libxl__gc *gc, libxl__device *device)
+                      device->devid);
+ }
+ 
++const char *libxl__live_device_backend_path(libxl__gc *gc, libxl__device *device)
++{
++    const char *libxl_dom_path = libxl__device_libxl_path(gc, device);
++    const char *be_path;
++    int rc;
++
++    rc = libxl__xs_read_checked(gc, XBT_NULL,
++                                GCSPRINTF("%s/backend", libxl_dom_path),
++                                &be_path);
++    if (rc)
++        /* read failure */
++        return NULL;
++    if (be_path)
++        return be_path;
++
++    /* fallback to constructing the path */
++    return libxl__device_backend_path(gc, device);
++}
++
+ char *libxl__domain_device_libxl_path(libxl__gc *gc,  uint32_t domid, uint32_t devid,
+                                       libxl__device_kind device_kind)
+ {
+@@ -986,7 +1005,7 @@ void libxl__initiate_device_generic_remove(libxl__egc *egc,
+ {
+     STATE_AO_GC(aodev->ao);
+     xs_transaction_t t = 0;
+-    char *be_path = libxl__device_backend_path(gc, aodev->dev);
++    const char *be_path = libxl__live_device_backend_path(gc, aodev->dev);
+     char *state_path = GCSPRINTF("%s/state", be_path);
+     char *online_path = GCSPRINTF("%s/online", be_path);
+     const char *state;
+@@ -994,6 +1013,17 @@ void libxl__initiate_device_generic_remove(libxl__egc *egc,
+     uint32_t my_domid, domid = aodev->dev->domid;
+     int rc = 0;
+ 
++    if (!aodev->dev->backend_domid) {
++        /*
++         * Deduce backend_domid if not given explicitly (left as 0), but don't
++         * override explicit non-zero value, to work also in the backend domain
++         * (not a toolstack domain).
++         */
++        rc = libxl__backendpath_parse_domid(gc, be_path,
++                                            &aodev->dev->backend_domid);
++        if (rc) goto out;
++    }
++
+     libxl_dominfo_init(&info);
+ 
+     rc = libxl__get_domid(gc, &my_domid);
+diff --git a/tools/libs/light/libxl_internal.h b/tools/libs/light/libxl_internal.h
+index cb9e8b3b8b5a..a8297f23b08a 100644
+--- a/tools/libs/light/libxl_internal.h
++++ b/tools/libs/light/libxl_internal.h
+@@ -1526,6 +1526,7 @@ _hidden char *libxl__domain_device_backend_path(libxl__gc *gc, uint32_t backend_
+ _hidden char *libxl__device_libxl_path(libxl__gc *gc, libxl__device *device);
+ _hidden char *libxl__domain_device_libxl_path(libxl__gc *gc, uint32_t domid, uint32_t devid,
+                                               libxl__device_kind device_kind);
++_hidden const char *libxl__live_device_backend_path(libxl__gc *gc, libxl__device *device);
+ _hidden int libxl__parse_backend_path(libxl__gc *gc, const char *path,
+                                       libxl__device *dev);
+ _hidden int libxl__console_tty_path(libxl__gc *gc, uint32_t domid, int cons_num,
+-- 
+2.37.3
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -108,6 +108,7 @@ _feature_patches=(
 	"0202-efi-Ensure-incorrectly-typed-runtime-services-get-ma.patch"
 	"0203-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch"
 	"0608-x86-time-Don-t-use-EFI-s-GetTime-call-by-default.patch"
+	"0611-libxl-do-not-require-filling-backend_domid-to-remove.patch"
 	"0613-Fix-buildid-alignment.patch"
 	"0626-Validate-EFI-memory-descriptors.patch"
 	"0630-Drop-ELF-notes-from-non-EFI-binary-too.patch"
@@ -151,6 +152,7 @@ _feature_patch_sums=(
 	"884f7f050085b6cc1c73d7ccbb6f946447c6fb09680686238630fa8b7dc7a68045836c7f60bdf5c8d3f938ab1f3d3182e92d02e2b9f2ed1c9bbfdd76ef6d0667" # 0202-efi-Ensure-incorrectly-typed-runtime-services-get-ma.patch
 	"d252beeb794477aa5d88cd0607eabb903f89f54465a0adf47f03cb95476b605ec5136b5e8aabd91af165af887ec68eb52f7190a3c7c929076e18a5f5fd58ce15" # 0203-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch
 	"7bad18013917be286c447d43d6bca2893ecba2e9f9ea33227515d7bdd1c97bdbd27cfdc187db8d8f782f72e4c89231b9e1f7d4d08a5c33c92b30598d426cf8ce" # 0608-x86-time-Don-t-use-EFI-s-GetTime-call-by-default.patch
+	"fede52636f5a3a653f51d5d9f65dcd17f11ff4d409a1a4df4dd8443cd59510eb3c6424c492bd8253f8ee60d883b92650baa0ec0e3e9104e63a9f94338df25d7a" # 0611-libxl-do-not-require-filling-backend_domid-to-remove.patch
 	"807923061899007ea5eb08f445ae6bcf35b07e44a3b6644f4ba05513819ce72d34e1824f2316019bc1688c1e9ddaa4e6512d9940641f04e2e63e1087a527b210" # 0613-Fix-buildid-alignment.patch
 	"e2105aa4f07bc3b9cf2b39ee0dc4e72d1dc3fc99212c126ba2889d79cc07c04ed0d33a0edb405c7ab48575fe225893c1c916ae808cd94dba00a910fd94c15ee8" # 0626-Validate-EFI-memory-descriptors.patch
 	"5e7ebb5ec7ea27b236707b0c761f52a9502c540471989d28dfb577cfadd9e995c09ae6baaae52fc76cd08afba4d04f241483f6c07a501ba445ecfdaa14d0c79e" # 0630-Drop-ELF-notes-from-non-EFI-binary-too.patch


### PR DESCRIPTION
Fixes device cleanup with driver domains in use (non-dom0 backend). The issue is the backend domain ID hasn't been explicitly specified, defaulting to 0, causing device cleanup to silently fail. However for a live domain the backend domain ID/path is present in the xenstore and thus can be unambigiously identified by the domU.