### PR TITLE
xen: Fix a race condition adding devices to stubdomains during startup

### DIFF
--- a/xen/0612-libxl-add-pcidevs-to-stubdomain-earlier.patch
+++ b/xen/0612-libxl-add-pcidevs-to-stubdomain-earlier.patch
@@ -1,0 +1,173 @@
+From af9bed0e0e40d28d8827d04bed64c554421456e7 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Thu, 30 Dec 2021 21:12:00 +0100
+Subject: [PATCH 12/26] libxl: add pcidevs to stubdomain earlier
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+When stubdomain is constructed, PCI devices were added during qemu
+startup (via hotplug path). While it makes the code (slightly) simpler,
+as it's more similar to no-stubdomain case, it also causes problems:
+ - race condition during stubdomain startup (QEMU trying to access sysfs
+   entries before xen-pcifront materialize them): QubesOS/qubes-issues#6203
+ - absent 0000:00:00.0 (host bridge) device during QEMU startup, which
+   breaks `igd-passthru=on` case: QubesOS/qubes-issues#7164
+
+While the first issue has alternative solution (retrying on failure),
+the second does not. In this case, QEMU tries to copy few parameters
+from the host bridge (apparently necessary for some drivers, although
+doesn't seem to affect Linux), even though only IGD is assigned. While
+0000:00:00.0 in (PV) stubdomain is not even a host bridge, it is the
+Intel graphics card (when it's assigned) and share the same values in
+config space offsets that QEMU reads (see hw/pci-host/xen_igd_pt.c in
+QEMU).
+
+So, to make QEMU happy and fix both issues at the same time, assign PCI
+devices before unpausing the stubdomain. This requires rather careful
+handling, as some steps need to be done only once (assigning to
+xen-pciback for example).
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_dm.c       | 34 +++++++++++++++++++++++++++++--
+ tools/libs/light/libxl_internal.h |  3 +++
+ tools/libs/light/libxl_pci.c      | 20 ++++++++++--------
+ 3 files changed, 46 insertions(+), 11 deletions(-)
+
+diff --git a/tools/libs/light/libxl_dm.c b/tools/libs/light/libxl_dm.c
+index 98b900bd7b9d..f5d930bb94f0 100644
+--- a/tools/libs/light/libxl_dm.c
++++ b/tools/libs/light/libxl_dm.c
+@@ -2233,6 +2233,9 @@ static void spawn_stubdom_pvqemu_cb(libxl__egc *egc,
+                                 libxl__dm_spawn_state *stubdom_dmss,
+                                 int rc);
+ 
++static void spawn_stub_pcis_dm(libxl__egc *egc,
++                               libxl__multidev *multidev, int ret);
++
+ static void spawn_stub_launch_dm(libxl__egc *egc,
+                                  libxl__multidev *aodevs, int ret);
+ 
+@@ -2438,7 +2441,7 @@ retry_transaction:
+             goto retry_transaction;
+ 
+     libxl__multidev_begin(ao, &sdss->multidev);
+-    sdss->multidev.callback = spawn_stub_launch_dm;
++    sdss->multidev.callback = spawn_stub_pcis_dm;
+     libxl__add_disks(egc, ao, dm_domid, dm_config, &sdss->multidev);
+     libxl__multidev_prepared(egc, &sdss->multidev, 0);
+ 
+@@ -2449,6 +2452,33 @@ out:
+     spawn_stubdom_pvqemu_cb(egc, &sdss->pvqemu, ret);
+ }
+ 
++static void spawn_stub_pcis_dm(libxl__egc *egc,
++                               libxl__multidev *multidev, int ret)
++{
++    libxl__stub_dm_spawn_state *sdss = CONTAINER_OF(multidev, *sdss, multidev);
++    STATE_AO_GC(sdss->dm.spawn.ao);
++
++    /* convenience aliases */
++    libxl_domain_config *const guest_config = sdss->dm.guest_config;
++    const int guest_domid = sdss->dm.guest_domid;
++    uint32_t dm_domid = sdss->pvqemu.guest_domid;
++
++    if (ret) {
++        LOGD(ERROR, guest_domid, "error connecting disk devices");
++        goto out;
++    }
++
++    libxl__multidev_begin(ao, &sdss->multidev);
++    sdss->multidev.callback = spawn_stub_launch_dm;
++    libxl__add_pcis(egc, ao, dm_domid, guest_config, &sdss->multidev);
++    libxl__multidev_prepared(egc, &sdss->multidev, 0);
++    return;
++
++out:
++    assert(ret);
++    spawn_stubdom_pvqemu_cb(egc, &sdss->pvqemu, ret);
++}
++
+ static void spawn_stub_launch_dm(libxl__egc *egc,
+                                  libxl__multidev *multidev, int ret)
+ {
+@@ -2468,7 +2498,7 @@ static void spawn_stub_launch_dm(libxl__egc *egc,
+     int need_qemu;
+ 
+     if (ret) {
+-        LOGD(ERROR, guest_domid, "error connecting disk devices");
++        LOGD(ERROR, guest_domid, "error connecting pci devices");
+         goto out;
+      }
+ 
+diff --git a/tools/libs/light/libxl_internal.h b/tools/libs/light/libxl_internal.h
+index a8297f23b08a..6df2452c6bd9 100644
+--- a/tools/libs/light/libxl_internal.h
++++ b/tools/libs/light/libxl_internal.h
+@@ -1732,6 +1732,9 @@ _hidden int libxl__device_pci_setdefault(libxl__gc *gc, uint32_t domid,
+                                          libxl_device_pci *pci, bool hotplug);
+ _hidden bool libxl__is_igd_vga_passthru(libxl__gc *gc,
+                                         const libxl_domain_config *d_config);
++_hidden void libxl__add_pcis(libxl__egc *egc, libxl__ao *ao, uint32_t domid,
++                             libxl_domain_config *d_config,
++                             libxl__multidev *multidev);
+ 
+ /* from libxl_dtdev */
+ 
+diff --git a/tools/libs/light/libxl_pci.c b/tools/libs/light/libxl_pci.c
+index b863da2f0d60..c9e01900ecfc 100644
+--- a/tools/libs/light/libxl_pci.c
++++ b/tools/libs/light/libxl_pci.c
+@@ -1434,10 +1434,6 @@ static void pci_add_dm_done(libxl__egc *egc,
+ 
+     if (rc) goto out;
+ 
+-    /* stubdomain is always running by now, even at create time */
+-    if (isstubdom)
+-        starting = false;
+-
+     sysfs_path = GCSPRINTF(SYSFS_PCI_DEV"/"PCI_BDF"/resource", pci->domain,
+                            pci->bus, pci->dev, pci->func);
+     f = fopen(sysfs_path, "r");
+@@ -1670,6 +1666,13 @@ void libxl__device_pci_add(libxl__egc *egc, uint32_t domid,
+     rc = libxl__device_pci_setdefault(gc, domid, pci, !starting);
+     if (rc) goto out;
+ 
++    stubdomid = libxl_get_stubdom_id(ctx, domid);
++    if (stubdomid != 0 && starting) {
++        /* Initial work already done when attaching to the stubdom */
++        device_pci_add_stubdom_done(egc, pas, 0); /* must be last */
++        return;
++    }
++
+     if (pci->seize && !pciback_dev_is_assigned(gc, pci)) {
+         rc = libxl__device_pci_assignable_add(gc, pci, 1);
+         if ( rc )
+@@ -1688,8 +1691,7 @@ void libxl__device_pci_add(libxl__egc *egc, uint32_t domid,
+ 
+     libxl__device_pci_reset(gc, pci->domain, pci->bus, pci->dev, pci->func);
+ 
+-    stubdomid = libxl_get_stubdom_id(ctx, domid);
+-    if (stubdomid != 0) {
++    if (stubdomid != 0 && !starting) {
+         pas->callback = device_pci_add_stubdom_wait;
+ 
+         do_pci_add(egc, stubdomid, pas); /* must be last */
+@@ -1831,9 +1833,9 @@ typedef struct {
+ 
+ static void add_pcis_done(libxl__egc *, libxl__multidev *, int rc);
+ 
+-static void libxl__add_pcis(libxl__egc *egc, libxl__ao *ao, uint32_t domid,
+-                            libxl_domain_config *d_config,
+-                            libxl__multidev *multidev)
++void libxl__add_pcis(libxl__egc *egc, libxl__ao *ao, uint32_t domid,
++                     libxl_domain_config *d_config,
++                     libxl__multidev *multidev)
+ {
+     AO_GC;
+     add_pcis_state *apds;
+-- 
+2.37.3
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -108,6 +108,7 @@ _feature_patches=(
 	"0202-efi-Ensure-incorrectly-typed-runtime-services-get-ma.patch"
 	"0203-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch"
 	"0608-x86-time-Don-t-use-EFI-s-GetTime-call-by-default.patch"
+	"0612-libxl-add-pcidevs-to-stubdomain-earlier.patch"
 	"0613-Fix-buildid-alignment.patch"
 	"0626-Validate-EFI-memory-descriptors.patch"
 	"0630-Drop-ELF-notes-from-non-EFI-binary-too.patch"
@@ -151,6 +152,7 @@ _feature_patch_sums=(
 	"884f7f050085b6cc1c73d7ccbb6f946447c6fb09680686238630fa8b7dc7a68045836c7f60bdf5c8d3f938ab1f3d3182e92d02e2b9f2ed1c9bbfdd76ef6d0667" # 0202-efi-Ensure-incorrectly-typed-runtime-services-get-ma.patch
 	"d252beeb794477aa5d88cd0607eabb903f89f54465a0adf47f03cb95476b605ec5136b5e8aabd91af165af887ec68eb52f7190a3c7c929076e18a5f5fd58ce15" # 0203-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch
 	"7bad18013917be286c447d43d6bca2893ecba2e9f9ea33227515d7bdd1c97bdbd27cfdc187db8d8f782f72e4c89231b9e1f7d4d08a5c33c92b30598d426cf8ce" # 0608-x86-time-Don-t-use-EFI-s-GetTime-call-by-default.patch
+	"b98a862c34efd2257e99164c04a5a49b85b05544f100f4eaa8e57a0e58890bdbb122030187a4b3db8173beb50ebda1d541f203b34d6482aec5ee61b583bcddcf" # 0612-libxl-add-pcidevs-to-stubdomain-earlier.patch
 	"807923061899007ea5eb08f445ae6bcf35b07e44a3b6644f4ba05513819ce72d34e1824f2316019bc1688c1e9ddaa4e6512d9940641f04e2e63e1087a527b210" # 0613-Fix-buildid-alignment.patch
 	"e2105aa4f07bc3b9cf2b39ee0dc4e72d1dc3fc99212c126ba2889d79cc07c04ed0d33a0edb405c7ab48575fe225893c1c916ae808cd94dba00a910fd94c15ee8" # 0626-Validate-EFI-memory-descriptors.patch
 	"5e7ebb5ec7ea27b236707b0c761f52a9502c540471989d28dfb577cfadd9e995c09ae6baaae52fc76cd08afba4d04f241483f6c07a501ba445ecfdaa14d0c79e" # 0630-Drop-ELF-notes-from-non-EFI-binary-too.patch


### PR DESCRIPTION
Fixes a race condition where QEMU tries to access sysfs entries before xen-pcifront materializes them, and a race condition where it breaks IGD passthrough. In the IGD case the IGD device would be assigned the PCI ID 0000:00:00.0 whereas that ID belongs to the host bridge. To fix both issues we assign all PCI devices before unpausing the stubdomain, effectively coldplugging them.