### PR TITLE
xen: Add stubdomain suspend-resume fixes

### DIFF
--- a/xen/0616-libxl-Add-a-utility-function-for-domain-resume.patch
+++ b/xen/0616-libxl-Add-a-utility-function-for-domain-resume.patch
@@ -1,0 +1,90 @@
+From d59d3e9799e24ae2aed3daa1454abbfa2d71b56b Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Mon, 26 Sep 2022 10:48:26 -0400
+Subject: [PATCH 16/26] libxl: Add a utility function for domain resume
+
+It is necessary to all xs_resume_domain after any successful call to
+xc_domain_resume, so that XenStore is notified of the resumption.
+However, it is also very easy to forget to call this.  This took me
+several days to debug.
+
+Fix this by adding a utility function to resume a domain and then notify
+XenStore of the resumption.  This function does not resume any device
+model, so it is still internal to libxl, but it makes future changes to
+libxl much less error-prone.  It also makes libxl itself smaller.
+
+Signed-off-by: Demi Marie Obenour <demi@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_dom_suspend.c | 41 +++++++++++++---------------
+ 1 file changed, 19 insertions(+), 22 deletions(-)
+
+diff --git a/tools/libs/light/libxl_dom_suspend.c b/tools/libs/light/libxl_dom_suspend.c
+index 4fa22bb73910..fa50e8801f35 100644
+--- a/tools/libs/light/libxl_dom_suspend.c
++++ b/tools/libs/light/libxl_dom_suspend.c
+@@ -451,6 +451,22 @@ int libxl__domain_resume_device_model_deprecated(libxl__gc *gc, uint32_t domid)
+     return 0;
+ }
+ 
++/* Just resumes the domain.  The device model must have been resumed already. */
++static int domain_resume_raw(libxl__gc *gc, uint32_t domid, int suspend_cancel)
++{
++    if (xc_domain_resume(CTX->xch, domid, suspend_cancel)) {
++        LOGED(ERROR, domid, "xc_domain_resume failed");
++        return ERROR_FAIL;
++    }
++
++    if (!xs_resume_domain(CTX->xsh, domid)) {
++        LOGED(ERROR, domid, "xs_resume_domain failed");
++        return ERROR_FAIL;
++    }
++
++    return 0;
++}
++
+ int libxl__domain_resume_deprecated(libxl__gc *gc, uint32_t domid, int suspend_cancel)
+ {
+     int rc = 0;
+@@ -469,16 +485,7 @@ int libxl__domain_resume_deprecated(libxl__gc *gc, uint32_t domid, int suspend_c
+         }
+     }
+ 
+-    if (xc_domain_resume(CTX->xch, domid, suspend_cancel)) {
+-        LOGED(ERROR, domid, "xc_domain_resume failed");
+-        rc = ERROR_FAIL;
+-        goto out;
+-    }
+-
+-    if (!xs_resume_domain(CTX->xsh, domid)) {
+-        LOGED(ERROR, domid, "xs_resume_domain failed");
+-        rc = ERROR_FAIL;
+-    }
++    rc = domain_resume_raw(gc, domid, suspend_cancel);
+ out:
+     return rc;
+ }
+@@ -660,19 +667,9 @@ static void domain_resume_done(libxl__egc *egc,
+     /* Convenience aliases */
+     libxl_domid domid = dmrs->domid;
+ 
+-    if (rc) goto out;
+-
+-    if (xc_domain_resume(CTX->xch, domid, dmrs->suspend_cancel)) {
+-        LOGED(ERROR, domid, "xc_domain_resume failed");
+-        rc = ERROR_FAIL;
+-        goto out;
+-    }
++    if (!rc)
++        rc = domain_resume_raw(gc, domid, dmrs->suspend_cancel);
+ 
+-    if (!xs_resume_domain(CTX->xsh, domid)) {
+-        LOGED(ERROR, domid, "xs_resume_domain failed");
+-        rc = ERROR_FAIL;
+-    }
+-out:
+     dmrs->callback(egc, dmrs, rc);
+ }
+ 
+-- 
+2.37.3
+

--- a/xen/0617-libxl-Add-utility-function-to-check-guest-status.patch
+++ b/xen/0617-libxl-Add-utility-function-to-check-guest-status.patch
@@ -1,0 +1,57 @@
+From 5998e60f71cc6f2904fb2e5e742ec3433e5b7b0c Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Mon, 26 Sep 2022 10:57:55 -0400
+Subject: [PATCH 17/26] libxl: Add utility function to check guest status
+
+This is used to check that a guest has not been destroyed and to obtain
+information about it.  It will be used in subsequent patches.
+
+Signed-off-by: Demi Marie Obenour <demi@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_dom_suspend.c | 19 ++++++++++++++-----
+ 1 file changed, 14 insertions(+), 5 deletions(-)
+
+diff --git a/tools/libs/light/libxl_dom_suspend.c b/tools/libs/light/libxl_dom_suspend.c
+index ce501a9326..5fac2fe36a 100644
+--- a/tools/libs/light/libxl_dom_suspend.c
++++ b/tools/libs/light/libxl_dom_suspend.c
+@@ -321,22 +321,31 @@ static void suspend_common_wait_guest_watch(libxl__egc *egc,
+     suspend_common_wait_guest_check(egc, dsps);
+ }
+ 
++static int check_guest_status(libxl__gc *gc, const uint32_t domid,
++                              xc_domaininfo_t *info, const char *what)
++{
++    int ret = xc_domain_getinfo_single(CTX->xch, domid, info);
++
++    if (ret < 0) {
++        LOGED(ERROR, domid, "guest we were %s has been destroyed", what);
++        return ERROR_FAIL;
++    }
++
++    return 0;
++}
++
+ static void suspend_common_wait_guest_check(libxl__egc *egc,
+         libxl__domain_suspend_state *dsps)
+ {
+     STATE_AO_GC(dsps->ao);
+     xc_domaininfo_t info;
+-    int ret;
+     int shutdown_reason;
+ 
+     /* Convenience aliases */
+     const uint32_t domid = dsps->domid;
+ 
+-    ret = xc_domain_getinfo_single(CTX->xch, domid, &info);
+-    if (ret < 0) {
+-        LOGED(ERROR, domid, "guest we were suspending has been destroyed");
++    if (check_guest_status(gc, domid, &info, "suspending"))
+         goto err;
+-    }
+ 
+     if (!(info.flags & XEN_DOMINF_shutdown))
+         /* keep waiting */
+-- 
+2.43.0
+

--- a/xen/0618-libxl-Properly-suspend-stubdomains.patch
+++ b/xen/0618-libxl-Properly-suspend-stubdomains.patch
@@ -1,0 +1,307 @@
+From 207582af51a027342e1f63d5c4497459aba4e67d Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Fri, 16 Sep 2022 07:31:57 -0400
+Subject: [PATCH 18/26] libxl: Properly suspend stubdomains
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Currently, libxl neither pauses nor suspends a stubdomain when
+suspending the domain it serves.  Qubes OS has an out-of-tree patch that
+just pauses the stubdomain, but that is also insufficient: sys-net (an
+HVM with an attached PCI device) does not properly resume from suspend
+on some systems, and the stubdomain considers the TSC clocksource to be
+unstable after resume.
+
+This patch properly suspends the stubdomain.  Doing so requires creating
+a nested libxl__domain_suspend_state structure and freeing it when
+necessary.  Additionally, a new callback function is added that runs
+when the stubdomain has been suspended.  libxl__qmp_suspend_save() is
+called by this new callback.
+
+Saving the state doesn't work on Qubes for two reasons:
+ - save/restore consoles are not enabled (as requiring qemu in dom0)
+ - avoid using QMP
+
+Link: https://github.com/QubesOS/qubes-issues/issues/7404
+Co-authored-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Signed-off-by: Demi Marie Obenour <demi@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_dom_suspend.c | 171 +++++++++++++++++++++++----
+ tools/libs/light/libxl_internal.h    |   1 +
+ 2 files changed, 150 insertions(+), 22 deletions(-)
+
+diff --git a/tools/libs/light/libxl_dom_suspend.c b/tools/libs/light/libxl_dom_suspend.c
+index d2a88ea34efb..d276b3c17e70 100644
+--- a/tools/libs/light/libxl_dom_suspend.c
++++ b/tools/libs/light/libxl_dom_suspend.c
+@@ -19,9 +19,9 @@
+ 
+ /*====================== Domain suspend =======================*/
+ 
+-int libxl__domain_suspend_init(libxl__egc *egc,
+-                               libxl__domain_suspend_state *dsps,
+-                               libxl_domain_type type)
++static int libxl__domain_suspend_init_inner(libxl__egc *egc,
++                                            libxl__domain_suspend_state *dsps,
++                                            libxl_domain_type type)
+ {
+     STATE_AO_GC(dsps->ao);
+     int rc = ERROR_FAIL;
+@@ -35,6 +35,7 @@ int libxl__domain_suspend_init(libxl__egc *egc,
+     libxl__ev_xswatch_init(&dsps->guest_watch);
+     libxl__ev_time_init(&dsps->guest_timeout);
+     libxl__ev_qmp_init(&dsps->qmp);
++    dsps->dm_dsps = dsps->parent_dsps = NULL;
+ 
+     if (type == LIBXL_DOMAIN_TYPE_INVALID) goto out;
+     dsps->type = type;
+@@ -67,18 +68,95 @@ out:
+     return rc;
+ }
+ 
++static void domain_suspend_device_model_domain_callback(libxl__egc *egc,
++                                       libxl__domain_suspend_state *dsps,
++                                       int rc);
++
++int libxl__domain_suspend_init(libxl__egc *egc,
++                               libxl__domain_suspend_state *dsps,
++                               libxl_domain_type type)
++{
++    STATE_AO_GC(dsps->ao);
++    uint32_t const domid = dsps->domid;
++    int rc = libxl__domain_suspend_init_inner(egc, dsps, type);
++
++    LOGD(DEBUG, domid, "Initialized suspend state");
++    if (type != LIBXL_DOMAIN_TYPE_HVM ||
++        !libxl__stubdomain_is_linux_running(gc, domid))
++        return rc;
++
++    LOGD(DEBUG, domid, "Need to suspend stubdomain too");
++    /* need to suspend the stubdomain too */
++    uint32_t const dm_domid = libxl_get_stubdom_id(CTX, domid);
++    if (rc == 0 && dm_domid != 0) {
++        libxl__domain_suspend_state *dm_dsps;
++
++        GCNEW(dm_dsps);
++        dm_dsps->domid = dm_domid;
++        dm_dsps->ao = dsps->ao;
++
++        dm_dsps->type = libxl__domain_type(gc, dm_domid);
++        if (dm_dsps->type == LIBXL_DOMAIN_TYPE_PV ||
++            dm_dsps->type == LIBXL_DOMAIN_TYPE_PVH) {
++            rc = libxl__domain_suspend_init_inner(egc, dm_dsps, dm_dsps->type);
++        } else {
++            LOGD(ERROR, domid, "Stubdomain %" PRIu32 " detected as neither PV "
++                               "nor PVH (got %d), cannot suspend", dm_domid, dm_dsps->type);
++            rc = ERROR_FAIL;
++        }
++        if (rc)
++            libxl__domain_suspend_dispose(gc, dsps);
++        else {
++            dm_dsps->callback_common_done = domain_suspend_device_model_domain_callback;
++            dsps->dm_dsps = dm_dsps;
++            dm_dsps->parent_dsps = dsps;
++        }
++    }
++    return rc;
++}
++
+ void libxl__domain_suspend_dispose(libxl__gc *gc,
+                                    libxl__domain_suspend_state  *dsps)
+ {
+-    libxl__xswait_stop(gc, &dsps->pvcontrol);
+-    libxl__ev_evtchn_cancel(gc, &dsps->guest_evtchn);
+-    libxl__ev_xswatch_deregister(gc, &dsps->guest_watch);
+-    libxl__ev_time_deregister(gc, &dsps->guest_timeout);
+-    libxl__ev_qmp_dispose(gc, &dsps->qmp);
++    for (;;) {
++        libxl__xswait_stop(gc, &dsps->pvcontrol);
++        libxl__ev_evtchn_cancel(gc, &dsps->guest_evtchn);
++        libxl__ev_xswatch_deregister(gc, &dsps->guest_watch);
++        libxl__ev_time_deregister(gc, &dsps->guest_timeout);
++        libxl__ev_qmp_dispose(gc, &dsps->qmp);
++        if (dsps->dm_dsps == NULL)
++            break;
++        assert(dsps->parent_dsps == NULL);
++        assert(dsps->dm_dsps->parent_dsps == dsps);
++        dsps = dsps->dm_dsps;
++        assert(dsps->dm_dsps == NULL);
++    }
+ }
+ 
+ /*----- callbacks, called by xc_domain_save -----*/
+ 
++static void domain_suspend_device_model_domain_callback(libxl__egc *egc,
++                                       libxl__domain_suspend_state *dm_dsps,
++                                       int rc)
++{
++    STATE_AO_GC(dm_dsps->ao);
++    libxl__domain_suspend_state *dsps = dm_dsps->parent_dsps;
++    assert(dm_dsps->dm_dsps == NULL);
++    assert(dsps);
++    assert(dsps->dm_dsps == dm_dsps);
++    if (rc) {
++        LOGD(ERROR, dsps->domid,
++             "failed to suspend device model (stubdom id %d), rc=%d", dm_dsps->domid, rc);
++    } else {
++        LOGD(DEBUG, dsps->domid,
++             "Successfully suspended stubdomain (stubdom id %d)", dm_dsps->domid);
++    }
++    dsps->callback_device_model_done(egc, dsps, rc); /* must be last */
++}
++
++static void domain_suspend_callback_common(libxl__egc *egc,
++                                           libxl__domain_suspend_state *dsps);
++
+ void libxl__domain_suspend_device_model(libxl__egc *egc,
+                                        libxl__domain_suspend_state *dsps)
+ {
+@@ -86,6 +164,7 @@ void libxl__domain_suspend_device_model(libxl__egc *egc,
+     int rc = 0;
+     uint32_t const domid = dsps->domid;
+     const char *const filename = dsps->dm_savefile;
++    libxl__domain_suspend_state *dm_dsps = dsps->dm_dsps;
+ 
+     switch (libxl__device_model_version_running(gc, domid)) {
+     case LIBXL_DEVICE_MODEL_VERSION_QEMU_XEN_TRADITIONAL: {
+@@ -95,15 +174,24 @@ void libxl__domain_suspend_device_model(libxl__egc *egc,
+         break;
+     }
+     case LIBXL_DEVICE_MODEL_VERSION_QEMU_XEN:
+-        /* calls dsps->callback_device_model_done when done */
+-        libxl__qmp_suspend_save(egc, dsps); /* must be last */
++        if (dm_dsps) {
++            assert(dm_dsps->type == LIBXL_DOMAIN_TYPE_PVH ||
++                   dm_dsps->type == LIBXL_DOMAIN_TYPE_PV);
++            LOGD(DEBUG, domid, "Suspending stubdomain (domid %" PRIu32 ")",
++                 dm_dsps->domid);
++            /* calls dm_dsps->callback_common_done when done */
++            domain_suspend_callback_common(egc, dm_dsps); /* must be last */
++        } else {
++            LOGD(DEBUG, domid, "Stubdomain not in use");
++            /* calls dsps->callback_device_model_done when done */
++            libxl__qmp_suspend_save(egc, dsps); /* must be last */
++        }
+         return;
+     default:
+         rc = ERROR_INVAL;
+-        goto out;
++        break;
+     }
+ 
+-out:
+     if (rc)
+         LOGD(ERROR, dsps->domid,
+              "failed to suspend device model, rc=%d", rc);
+@@ -130,8 +218,6 @@ static void domain_suspend_common_done(libxl__egc *egc,
+                                        libxl__domain_suspend_state *dsps,
+                                        int rc);
+ 
+-static void domain_suspend_callback_common(libxl__egc *egc,
+-                                           libxl__domain_suspend_state *dsps);
+ static void domain_suspend_callback_common_done(libxl__egc *egc,
+                                 libxl__domain_suspend_state *dsps, int rc);
+ 
+@@ -308,6 +394,7 @@ static void domain_suspend_common_wait_guest(libxl__egc *egc,
+                                      suspend_common_wait_guest_timeout,
+                                      60*1000);
+     if (rc) goto err;
++
+     return;
+ 
+  err:
+@@ -528,6 +615,7 @@ void libxl__dm_resume(libxl__egc *egc,
+ {
+     STATE_AO_GC(dmrs->ao);
+     int rc = 0;
++    uint32_t dm_domid = libxl_get_stubdom_id(CTX, dmrs->domid);
+ 
+     /* Convenience aliases */
+     libxl_domid domid = dmrs->domid;
+@@ -543,7 +631,6 @@ void libxl__dm_resume(libxl__egc *egc,
+ 
+     switch (libxl__device_model_version_running(gc, domid)) {
+     case LIBXL_DEVICE_MODEL_VERSION_QEMU_XEN_TRADITIONAL: {
+-        uint32_t dm_domid = libxl_get_stubdom_id(CTX, domid);
+         const char *path, *state;
+ 
+         path = DEVICE_MODEL_XS_PATH(gc, dm_domid, domid, "/state");
+@@ -563,14 +650,54 @@ void libxl__dm_resume(libxl__egc *egc,
+         if (rc) goto out;
+         break;
+     }
+-    case LIBXL_DEVICE_MODEL_VERSION_QEMU_XEN:
+-        qmp->ao = dmrs->ao;
+-        qmp->domid = domid;
+-        qmp->callback = dm_resume_qmp_done;
+-        qmp->payload_fd = -1;
+-        rc = libxl__ev_qmp_send(egc, qmp, "cont", NULL);
++    case LIBXL_DEVICE_MODEL_VERSION_QEMU_XEN: {
++        xc_domaininfo_t dm_info;
++
++        if (dm_domid == 0 /* || !libxl__stubdomain_is_linux_running() */) {
++            LOGD(DEBUG, domid, "Resuming dom0 device model using QMP");
++            qmp->ao = dmrs->ao;
++            qmp->domid = domid;
++            qmp->callback = dm_resume_qmp_done;
++            qmp->payload_fd = -1;
++            rc = libxl__ev_qmp_send(egc, qmp, "cont", NULL);
++            if (rc) goto out;
++            return;
++        }
++
++        LOGD(DEBUG, domid, "Resuming modern stubdomain: ID %" PRIu32, dm_domid);
++
++        rc = check_guest_status(gc, dm_domid, &dm_info, "resuming");
+         if (rc) goto out;
+-        break;
++
++        if ((dm_info.flags & XEN_DOMINF_paused)) {
++            rc = xc_domain_unpause(CTX->xch, dm_domid);
++            if (rc < 0) {
++                LOGED(ERROR, domid,
++                      "xc_domain_unpause failed for stubdomain %" PRIu32,
++                      dm_domid);
++                goto out;
++            }
++            LOGD(DEBUG, domid,
++                 "xc_domain_unpause succeeded for stubdomain %" PRIu32,
++                 dm_domid);
++        }
++
++        if ((dm_info.flags & XEN_DOMINF_shutdown)) {
++            int shutdown_reason =
++                (dm_info.flags >> XEN_DOMINF_shutdownshift)
++                & XEN_DOMINF_shutdownmask;
++            if (shutdown_reason != SHUTDOWN_suspend) {
++                LOGD(ERROR, domid, "stubdomain %d being resumed shut down"
++                     " with unexpected reason code %d",
++                     dm_domid, shutdown_reason);
++                rc = ERROR_FAIL;
++                goto out;
++            }
++
++            rc = domain_resume_raw(gc, dm_domid, dmrs->suspend_cancel);
++        }
++        goto out;
++    }
+     default:
+         rc = ERROR_INVAL;
+         goto out;
+diff --git a/tools/libs/light/libxl_internal.h b/tools/libs/light/libxl_internal.h
+index 6df2452c6bd9..a86c21a7ce21 100644
+--- a/tools/libs/light/libxl_internal.h
++++ b/tools/libs/light/libxl_internal.h
+@@ -3631,6 +3631,7 @@ struct libxl__domain_suspend_state {
+                               struct libxl__domain_suspend_state*, int rc);
+     void (*callback_common_done)(libxl__egc*,
+                                  struct libxl__domain_suspend_state*, int ok);
++    struct libxl__domain_suspend_state *dm_dsps, *parent_dsps;
+ };
+ int libxl__domain_suspend_init(libxl__egc *egc,
+                                libxl__domain_suspend_state *dsps,
+-- 
+2.37.3
+

--- a/xen/0619-libxl-Fix-race-condition-in-domain-suspension.patch
+++ b/xen/0619-libxl-Fix-race-condition-in-domain-suspension.patch
@@ -1,0 +1,75 @@
+From a7d721415da567e40ae1932c853cca074f45cff6 Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Thu, 22 Sep 2022 12:27:32 -0400
+Subject: [PATCH 19/26] libxl: Fix race condition in domain suspension
+
+Check if the domain has suspended after setting the XenStore watch to
+prevent race conditions.  Also check if a guest has suspended when the
+timeout handler is called, and do not consider this to be a timeout.
+
+Signed-off-by: Demi Marie Obenour <demi@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_dom_suspend.c | 15 +++++++++++----
+ 1 file changed, 11 insertions(+), 4 deletions(-)
+
+diff --git a/tools/libs/light/libxl_dom_suspend.c b/tools/libs/light/libxl_dom_suspend.c
+index d276b3c17e70..42c0e0a152e0 100644
+--- a/tools/libs/light/libxl_dom_suspend.c
++++ b/tools/libs/light/libxl_dom_suspend.c
+@@ -209,7 +209,8 @@ static void domain_suspend_common_wait_guest_evtchn(libxl__egc *egc,
+         libxl__ev_evtchn *evev);
+ static void suspend_common_wait_guest_watch(libxl__egc *egc,
+       libxl__ev_xswatch *xsw, const char *watch_path, const char *event_path);
+-static void suspend_common_wait_guest_check(libxl__egc *egc,
++/* Returns true if a callback was called, false otherwise */
++static bool suspend_common_wait_guest_check(libxl__egc *egc,
+         libxl__domain_suspend_state *dsps);
+ static void suspend_common_wait_guest_timeout(libxl__egc *egc,
+       libxl__ev_time *ev, const struct timeval *requested_abs, int rc);
+@@ -426,7 +427,7 @@ static int check_guest_status(libxl__gc *gc, const uint32_t domid,
+     return 0;
+ }
+ 
+-static void suspend_common_wait_guest_check(libxl__egc *egc,
++static bool suspend_common_wait_guest_check(libxl__egc *egc,
+         libxl__domain_suspend_state *dsps)
+ {
+     STATE_AO_GC(dsps->ao);
+@@ -441,7 +442,7 @@ static void suspend_common_wait_guest_check(libxl__egc *egc,
+ 
+     if (!(info.flags & XEN_DOMINF_shutdown))
+         /* keep waiting */
+-        return;
++        return false;
+ 
+     shutdown_reason = (info.flags >> XEN_DOMINF_shutdownshift)
+         & XEN_DOMINF_shutdownmask;
+@@ -452,11 +453,15 @@ static void suspend_common_wait_guest_check(libxl__egc *egc,
+     }
+ 
+     LOGD(DEBUG, domid, "guest has suspended");
++    dsps->guest_responded = 1;
++    libxl__xswait_stop(gc, &dsps->pvcontrol);
+     domain_suspend_common_guest_suspended(egc, dsps);
+-    return;
++    return true;
+ 
+  err:
++    libxl__xswait_stop(gc, &dsps->pvcontrol);
+     domain_suspend_common_done(egc, dsps, ERROR_FAIL);
++    return true;
+ }
+ 
+ static void suspend_common_wait_guest_timeout(libxl__egc *egc,
+@@ -464,6 +469,8 @@ static void suspend_common_wait_guest_timeout(libxl__egc *egc,
+ {
+     libxl__domain_suspend_state *dsps = CONTAINER_OF(ev, *dsps, guest_timeout);
+     STATE_AO_GC(dsps->ao);
++    if (suspend_common_wait_guest_check(egc, dsps))
++        return;
+     if (rc == ERROR_TIMEDOUT) {
+         LOGD(ERROR, dsps->domid, "guest did not suspend, timed out");
+         rc = ERROR_GUEST_TIMEDOUT;
+-- 
+2.37.3
+

--- a/xen/0620-libxl-Add-additional-domain-suspend-resume-logs.patch
+++ b/xen/0620-libxl-Add-additional-domain-suspend-resume-logs.patch
@@ -1,0 +1,118 @@
+From 1227dd53e848563f1552afdf04d4d32b1f1d440f Mon Sep 17 00:00:00 2001
+From: Demi Marie Obenour <demi@invisiblethingslab.com>
+Date: Mon, 26 Sep 2022 11:05:32 -0400
+Subject: [PATCH 20/26] libxl: Add additional domain suspend/resume logs
+
+This was useful when debugging, but is not required.
+
+Signed-off-by: Demi Marie Obenour <demi@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_dom_suspend.c | 20 ++++++++++++++++++--
+ tools/libs/light/libxl_domain.c      |  1 +
+ 2 files changed, 19 insertions(+), 2 deletions(-)
+
+diff --git a/tools/libs/light/libxl_dom_suspend.c b/tools/libs/light/libxl_dom_suspend.c
+index 42c0e0a152e0..55a172a46f87 100644
+--- a/tools/libs/light/libxl_dom_suspend.c
++++ b/tools/libs/light/libxl_dom_suspend.c
+@@ -321,9 +321,11 @@ static void domain_suspend_common_pvcontrol_suspending(libxl__egc *egc,
+     STATE_AO_GC(dsps->ao);
+     xs_transaction_t t = 0;
+ 
+-    if (!rc && !domain_suspend_pvcontrol_acked(state))
++    if (!rc && !domain_suspend_pvcontrol_acked(state)) {
+         /* keep waiting */
++        LOGD(DEBUG, dsps->domid, "PV control callback without ack");
+         return;
++    }
+ 
+     libxl__xswait_stop(gc, &dsps->pvcontrol);
+ 
+@@ -405,7 +407,10 @@ static void domain_suspend_common_wait_guest(libxl__egc *egc,
+ static void suspend_common_wait_guest_watch(libxl__egc *egc,
+       libxl__ev_xswatch *xsw, const char *watch_path, const char *event_path)
+ {
++    EGC_GC;
+     libxl__domain_suspend_state *dsps = CONTAINER_OF(xsw, *dsps, guest_watch);
++
++    LOGD(DEBUG, dsps->domid, "@releaseDomain watch fired, checking guest status");
+     suspend_common_wait_guest_check(egc, dsps);
+ }
+ 
+@@ -440,9 +445,11 @@ static bool suspend_common_wait_guest_check(libxl__egc *egc,
+     if (check_guest_status(gc, domid, &info, "suspending"))
+         goto err;
+ 
+-    if (!(info.flags & XEN_DOMINF_shutdown))
++    if (!(info.flags & XEN_DOMINF_shutdown)) {
++        LOGD(DEBUG, domid, "guest we were suspending has not shut down yet");
+         /* keep waiting */
+         return false;
++    }
+ 
+     shutdown_reason = (info.flags >> XEN_DOMINF_shutdownshift)
+         & XEN_DOMINF_shutdownmask;
+@@ -469,11 +476,14 @@ static void suspend_common_wait_guest_timeout(libxl__egc *egc,
+ {
+     libxl__domain_suspend_state *dsps = CONTAINER_OF(ev, *dsps, guest_timeout);
+     STATE_AO_GC(dsps->ao);
++    LOGD(DEBUG, dsps->domid, "Timeout callback triggered");
+     if (suspend_common_wait_guest_check(egc, dsps))
+         return;
+     if (rc == ERROR_TIMEDOUT) {
+         LOGD(ERROR, dsps->domid, "guest did not suspend, timed out");
+         rc = ERROR_GUEST_TIMEDOUT;
++    } else {
++        LOGD(ERROR, dsps->domid, "error in timeout handler (code %d)", rc);
+     }
+     domain_suspend_common_done(egc, dsps, rc);
+ }
+@@ -628,6 +638,8 @@ void libxl__dm_resume(libxl__egc *egc,
+     libxl_domid domid = dmrs->domid;
+     libxl__ev_qmp *qmp = &dmrs->qmp;
+ 
++    LOGD(DEBUG, domid, "Resuming device model");
++
+     dm_resume_init(dmrs);
+ 
+     rc = libxl__ev_time_register_rel(dmrs->ao,
+@@ -640,6 +652,7 @@ void libxl__dm_resume(libxl__egc *egc,
+     case LIBXL_DEVICE_MODEL_VERSION_QEMU_XEN_TRADITIONAL: {
+         const char *path, *state;
+ 
++        LOGD(DEBUG, domid, "Resuming legacy device model: stubdomain ID %" PRIu32, dm_domid);
+         path = DEVICE_MODEL_XS_PATH(gc, dm_domid, domid, "/state");
+         rc = libxl__xs_read_checked(gc, XBT_NULL, path, &state);
+         if (rc) goto out;
+@@ -706,6 +719,7 @@ void libxl__dm_resume(libxl__egc *egc,
+         goto out;
+     }
+     default:
++        LOGD(ERROR, domid, "Invalid device model type, cannot resume");
+         rc = ERROR_INVAL;
+         goto out;
+     }
+@@ -782,6 +796,8 @@ void libxl__domain_resume(libxl__egc *egc,
+     int rc = 0;
+     libxl_domain_type type = libxl__domain_type(gc, dmrs->domid);
+ 
++    LOGD(DEBUG, dmrs->domid, "Resuming domain");
++
+     if (type == LIBXL_DOMAIN_TYPE_INVALID) {
+         rc = ERROR_FAIL;
+         goto out;
+diff --git a/tools/libs/light/libxl_domain.c b/tools/libs/light/libxl_domain.c
+index 7f0986c18569..f518daada6c9 100644
+--- a/tools/libs/light/libxl_domain.c
++++ b/tools/libs/light/libxl_domain.c
+@@ -567,6 +567,7 @@ int libxl_domain_suspend_only(libxl_ctx *ctx, uint32_t domid,
+     dsps->ao = ao;
+     dsps->domid = domid;
+     dsps->type = type;
++    LOGD(DEBUG, domid, "Received request to suspend domain");
+     rc = libxl__domain_suspend_init(egc, dsps, type);
+     if (rc < 0) goto out_err;
+     dsps->callback_common_done = domain_suspend_empty_cb;
+-- 
+2.37.3
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -109,6 +109,11 @@ _feature_patches=(
 	"0203-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch"
 	"0608-x86-time-Don-t-use-EFI-s-GetTime-call-by-default.patch"
 	"0613-Fix-buildid-alignment.patch"
+	"0616-libxl-Add-a-utility-function-for-domain-resume.patch"
+	"0617-libxl-Add-utility-function-to-check-guest-status.patch"
+	"0618-libxl-Properly-suspend-stubdomains.patch"
+	"0619-libxl-Fix-race-condition-in-domain-suspension.patch"
+	"0620-libxl-Add-additional-domain-suspend-resume-logs.patch"
 	"0626-Validate-EFI-memory-descriptors.patch"
 	"0630-Drop-ELF-notes-from-non-EFI-binary-too.patch"
 )
@@ -152,6 +157,11 @@ _feature_patch_sums=(
 	"d252beeb794477aa5d88cd0607eabb903f89f54465a0adf47f03cb95476b605ec5136b5e8aabd91af165af887ec68eb52f7190a3c7c929076e18a5f5fd58ce15" # 0203-Add-xen.cfg-options-for-mapbs-and-noexitboot.patch
 	"7bad18013917be286c447d43d6bca2893ecba2e9f9ea33227515d7bdd1c97bdbd27cfdc187db8d8f782f72e4c89231b9e1f7d4d08a5c33c92b30598d426cf8ce" # 0608-x86-time-Don-t-use-EFI-s-GetTime-call-by-default.patch
 	"807923061899007ea5eb08f445ae6bcf35b07e44a3b6644f4ba05513819ce72d34e1824f2316019bc1688c1e9ddaa4e6512d9940641f04e2e63e1087a527b210" # 0613-Fix-buildid-alignment.patch
+	"653732bb05d359118e16fa2fdf5637d49493563ad606e467e9e38afdd796382d2c07e671481850c317a1ee04daf9198df248b6d7010a831c8815c33cf41f1ac1" # 0616-libxl-Add-a-utility-function-for-domain-resume.patch
+	"3a6269b4b17502ae083d2e211ea7a2edfd1f4a333ce0744354f2ccd3acf8ff20eab56c1fd1278ed07fcfa7b0b954bdaac308f789e344be1a2e9bde1c64691f63" # 0617-libxl-Add-utility-function-to-check-guest-status.patch
+	"e02dcaaef6ed5028e708c4a4eae4baf79a37a2ae70f1d760a91b40874c4959c21e5ea76af30059eab5c203b0ae34fb4f6a470cf81090167821358a532df9eb4e" # 0618-libxl-Properly-suspend-stubdomains.patch
+	"06840486624986b1c096b12436e5225a4f7b19c9831777151a60d64ec59e372bc75dd1a7068dcea2826ae4d43ca160104db0dba42c346b7da09453163d0c57fc" # 0619-libxl-Fix-race-condition-in-domain-suspension.patch
+	"04f0c48d916d201e68c2203fd6ac50857ec8ddc99a0e60754ebe6b22508e45fae9b21725476dfc1639211729aa108f5c49efa79860d6f31d415d89dc5b408634" # 0620-libxl-Add-additional-domain-suspend-resume-logs.patch
 	"e2105aa4f07bc3b9cf2b39ee0dc4e72d1dc3fc99212c126ba2889d79cc07c04ed0d33a0edb405c7ab48575fe225893c1c916ae808cd94dba00a910fd94c15ee8" # 0626-Validate-EFI-memory-descriptors.patch
 	"5e7ebb5ec7ea27b236707b0c761f52a9502c540471989d28dfb577cfadd9e995c09ae6baaae52fc76cd08afba4d04f241483f6c07a501ba445ecfdaa14d0c79e" # 0630-Drop-ELF-notes-from-non-EFI-binary-too.patch
 )


### PR DESCRIPTION
Fixes several issues with domain suspension when stubdomains are used. While exposed in libxl this functionality is not exposed in the `xl` tool. However domains can be suspended and resumed by libvirt, and this functionality is trivial to add to the `xl` tool. Right now I am including this to support this functionality through libvirt, though we could add this functionality to `xl` if there's interest.