### PR TITLE
xen: Workaround Windows PV drivers removing control/shutdown mode

### DIFF
--- a/xen/0621-libxl-workaround-for-Windows-PV-drivers-removing-con.patch
+++ b/xen/0621-libxl-workaround-for-Windows-PV-drivers-removing-con.patch
@@ -1,0 +1,74 @@
+From 9573fd4455bcfb04494068e32b95ae744961ebf2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Thu, 27 Oct 2022 21:16:18 +0200
+Subject: [PATCH 21/26] libxl: workaround for Windows PV drivers removing
+ control/shutdown node
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+win-pv-drivers 8.x remove control/shutdown node as an acknowledgement,
+instead of just clearing the content. This means the subsequent write
+will create it anew, with default permissions (dom0 write, guest read).
+Such permissions won't allow the guest to acknowledge subsequent
+requests.
+
+Workaround the issue by explicitly setting permissions after the write.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_domain.c | 28 ++++++++++++++++++++++++++--
+ 1 file changed, 26 insertions(+), 2 deletions(-)
+
+diff --git a/tools/libs/light/libxl_domain.c b/tools/libs/light/libxl_domain.c
+index f518daada6c9..6451b4a145ee 100644
+--- a/tools/libs/light/libxl_domain.c
++++ b/tools/libs/light/libxl_domain.c
+@@ -771,7 +771,12 @@ int libxl__domain_pvcontrol(libxl__egc *egc, libxl__xswait_state *pvcontrol,
+                             domid_t domid, const char *cmd)
+ {
+     STATE_AO_GC(pvcontrol->ao);
++    libxl_ctx *ctx = libxl__gc_owner(gc);
+     const char *shutdown_path;
++    xs_transaction_t t;
++    struct xs_permissions perms[] = {
++        { .id = domid, .perms = XS_PERM_NONE },
++    };
+     int rc;
+ 
+     rc = libxl__domain_pvcontrol_available(gc, domid);
+@@ -785,9 +790,28 @@ int libxl__domain_pvcontrol(libxl__egc *egc, libxl__xswait_state *pvcontrol,
+     if (!shutdown_path)
+         return ERROR_FAIL;
+ 
+-    rc = libxl__xs_printf(gc, XBT_NULL, shutdown_path, "%s", cmd);
+-    if (rc)
++ retry_transaction:
++    t = xs_transaction_start(ctx->xsh);
++    if (!t)
++        return ERROR_FAIL;
++
++    rc = libxl__xs_printf(gc, t, shutdown_path, "%s", cmd);
++    if (rc) {
++        xs_transaction_end(ctx->xsh, t, 1);
+         return rc;
++    }
++
++    if (!xs_set_permissions(ctx->xsh, t, shutdown_path, perms, ARRAY_SIZE(perms))) {
++        xs_transaction_end(ctx->xsh, t, 1);
++        return ERROR_FAIL;
++    }
++
++    if (!xs_transaction_end(ctx->xsh, t, 0)) {
++        if (errno == EAGAIN)
++            goto retry_transaction;
++        else
++            return ERROR_FAIL;
++    }
+ 
+     pvcontrol->path = shutdown_path;
+     pvcontrol->what = GCSPRINTF("guest acknowledgement of %s request", cmd);
+-- 
+2.37.3
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -122,6 +122,7 @@ _feature_patches=(
 	"0618-libxl-Properly-suspend-stubdomains.patch"
 	"0619-libxl-Fix-race-condition-in-domain-suspension.patch"
 	"0620-libxl-Add-additional-domain-suspend-resume-logs.patch"
+	"0621-libxl-workaround-for-Windows-PV-drivers-removing-con.patch"
 	"0626-Validate-EFI-memory-descriptors.patch"
 	"0630-Drop-ELF-notes-from-non-EFI-binary-too.patch"
 )
@@ -178,6 +179,7 @@ _feature_patch_sums=(
 	"e02dcaaef6ed5028e708c4a4eae4baf79a37a2ae70f1d760a91b40874c4959c21e5ea76af30059eab5c203b0ae34fb4f6a470cf81090167821358a532df9eb4e" # 0618-libxl-Properly-suspend-stubdomains.patch
 	"06840486624986b1c096b12436e5225a4f7b19c9831777151a60d64ec59e372bc75dd1a7068dcea2826ae4d43ca160104db0dba42c346b7da09453163d0c57fc" # 0619-libxl-Fix-race-condition-in-domain-suspension.patch
 	"04f0c48d916d201e68c2203fd6ac50857ec8ddc99a0e60754ebe6b22508e45fae9b21725476dfc1639211729aa108f5c49efa79860d6f31d415d89dc5b408634" # 0620-libxl-Add-additional-domain-suspend-resume-logs.patch
+	"31f88b392e8c04929ee63e2b067f93fa015a2c52d0731356f5888a3ab878f2c9c9eb1d21e4fb26a32c7d93c458c7049afac3991a3c6ef34c96f218183da84192" # 0621-libxl-workaround-for-Windows-PV-drivers-removing-con.patch
 	"e2105aa4f07bc3b9cf2b39ee0dc4e72d1dc3fc99212c126ba2889d79cc07c04ed0d33a0edb405c7ab48575fe225893c1c916ae808cd94dba00a910fd94c15ee8" # 0626-Validate-EFI-memory-descriptors.patch
 	"5e7ebb5ec7ea27b236707b0c761f52a9502c540471989d28dfb577cfadd9e995c09ae6baaae52fc76cd08afba4d04f241483f6c07a501ba445ecfdaa14d0c79e" # 0630-Drop-ELF-notes-from-non-EFI-binary-too.patch
 )


### PR DESCRIPTION
win-pv-drivers 8.x remove control/shutdown node as an acknowledgement,
instead of just clearing the content. This means the subsequent write
will create it anew, with default permissions (dom0 write, guest read).
Such permissions won't allow the guest to acknowledge subsequent
requests.

Workaround the issue by explicitly setting permissions after the write.