### PR TITLE
xen: Check control/feature-* before issuing pvcontrol command

### DIFF
--- a/xen/0622-libxl-check-control-feature-before-issuing-pvcontrol.patch
+++ b/xen/0622-libxl-check-control-feature-before-issuing-pvcontrol.patch
@@ -1,0 +1,49 @@
+From 4b602273b9d179ef2c375c7db7d3d1fbb9546c9f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Thu, 27 Oct 2022 21:27:05 +0200
+Subject: [PATCH 22/26] libxl: check control/feature-* before issuing pvcontrol
+ command
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Check early, instead of waiting for a timeout. This is relevant for
+example for Mirage OS PVH domain, which doesn't support suspend.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_domain.c | 10 ++++++++++
+ 1 file changed, 10 insertions(+)
+
+diff --git a/tools/libs/light/libxl_domain.c b/tools/libs/light/libxl_domain.c
+index 6451b4a145ee..0d5d1ef6663c 100644
+--- a/tools/libs/light/libxl_domain.c
++++ b/tools/libs/light/libxl_domain.c
+@@ -777,6 +777,7 @@ int libxl__domain_pvcontrol(libxl__egc *egc, libxl__xswait_state *pvcontrol,
+     struct xs_permissions perms[] = {
+         { .id = domid, .perms = XS_PERM_NONE },
+     };
++    char *feature;
+     int rc;
+ 
+     rc = libxl__domain_pvcontrol_available(gc, domid);
+@@ -795,6 +796,15 @@ int libxl__domain_pvcontrol(libxl__egc *egc, libxl__xswait_state *pvcontrol,
+     if (!t)
+         return ERROR_FAIL;
+ 
++    feature = libxl__xs_read(gc, t, GCSPRINTF("%s/control/feature-%s",
++                                              libxl__xs_get_dompath(gc, domid),
++                                              cmd));
++    if (!feature || strcmp(feature, "1")) {
++        LOGD(ERROR, domid, "PV control '%s' not supported by this domain", cmd);
++        xs_transaction_end(ctx->xsh, t, 1);
++        return ERROR_NOPARAVIRT;
++    }
++
+     rc = libxl__xs_printf(gc, t, shutdown_path, "%s", cmd);
+     if (rc) {
+         xs_transaction_end(ctx->xsh, t, 1);
+-- 
+2.37.3
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -122,6 +122,7 @@ _feature_patches=(
 	"0618-libxl-Properly-suspend-stubdomains.patch"
 	"0619-libxl-Fix-race-condition-in-domain-suspension.patch"
 	"0620-libxl-Add-additional-domain-suspend-resume-logs.patch"
+	"0622-libxl-check-control-feature-before-issuing-pvcontrol.patch"
 	"0626-Validate-EFI-memory-descriptors.patch"
 	"0630-Drop-ELF-notes-from-non-EFI-binary-too.patch"
 )
@@ -178,6 +179,7 @@ _feature_patch_sums=(
 	"e02dcaaef6ed5028e708c4a4eae4baf79a37a2ae70f1d760a91b40874c4959c21e5ea76af30059eab5c203b0ae34fb4f6a470cf81090167821358a532df9eb4e" # 0618-libxl-Properly-suspend-stubdomains.patch
 	"06840486624986b1c096b12436e5225a4f7b19c9831777151a60d64ec59e372bc75dd1a7068dcea2826ae4d43ca160104db0dba42c346b7da09453163d0c57fc" # 0619-libxl-Fix-race-condition-in-domain-suspension.patch
 	"04f0c48d916d201e68c2203fd6ac50857ec8ddc99a0e60754ebe6b22508e45fae9b21725476dfc1639211729aa108f5c49efa79860d6f31d415d89dc5b408634" # 0620-libxl-Add-additional-domain-suspend-resume-logs.patch
+	"420eb0da3f241308c787c97c2c5404a16560d83efb6d985c5abd7fc6073917931ed5eca74444f195329202652c559a846e46238d30a2aeafd456b4cdeb0312ff" # 0622-libxl-check-control-feature-before-issuing-pvcontrol.patch
 	"e2105aa4f07bc3b9cf2b39ee0dc4e72d1dc3fc99212c126ba2889d79cc07c04ed0d33a0edb405c7ab48575fe225893c1c916ae808cd94dba00a910fd94c15ee8" # 0626-Validate-EFI-memory-descriptors.patch
 	"5e7ebb5ec7ea27b236707b0c761f52a9502c540471989d28dfb577cfadd9e995c09ae6baaae52fc76cd08afba4d04f241483f6c07a501ba445ecfdaa14d0c79e" # 0630-Drop-ELF-notes-from-non-EFI-binary-too.patch
 )


### PR DESCRIPTION
This stops libxl from waiting for a timeout. This is relevant for domains that don't support suspension.