### PR TITLE
xen: Enable interrupt processing for stubdomains

### DIFF
--- a/xen/0625-libxl-Allow-stubdomain-to-control-interupts-of-PCI-d.patch
+++ b/xen/0625-libxl-Allow-stubdomain-to-control-interupts-of-PCI-d.patch
@@ -1,0 +1,44 @@
+From f139b8e8b64bf5bca7f32b9c35ac6af6db4a0bb8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Wed, 16 Nov 2022 01:31:42 +0100
+Subject: [PATCH 25/26] libxl: Allow stubdomain to control interupts of PCI
+ device
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Especially allow it to control MSI/MSI-X enabling bits. This part only
+writes a flag to a sysfs, the actual implementation is on the kernel
+side.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_pci.c | 11 +++++++++++
+ 1 file changed, 11 insertions(+)
+
+diff --git a/tools/libs/light/libxl_pci.c b/tools/libs/light/libxl_pci.c
+index c9e01900ecfc..2f73e963d028 100644
+--- a/tools/libs/light/libxl_pci.c
++++ b/tools/libs/light/libxl_pci.c
+@@ -1512,6 +1512,17 @@ static void pci_add_dm_done(libxl__egc *egc,
+             rc = ERROR_FAIL;
+             goto out;
+         }
++    } else if (libxl_is_stubdom(ctx, domid, NULL)) {
++        /* Allow acces to MSI enable flag in PCI config space for the stubdom */
++        if ( sysfs_write_bdf(gc, SYSFS_PCIBACK_DRIVER"/allow_interrupt_control",
++                             pci) < 0 ) {
++            if ( sysfs_write_bdf(gc, SYSFS_PCIBACK_DRIVER"/allow_msi_enable",
++                                 pci) < 0 ) {
++                LOGD(ERROR, domainid, "Setting allow_msi_enable for device");
++                rc = ERROR_FAIL;
++                goto out;
++            }
++        }
+     }
+ 
+ out_no_irq:
+-- 
+2.37.3
+

--- a/xen/0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch
+++ b/xen/0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch
@@ -1,0 +1,224 @@
+From ae59e1ceeccb68d9a955418f95721ddc231fe76f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Mon, 14 Nov 2022 13:56:56 +0100
+Subject: [PATCH 1/2] x86/msi: passthrough all MSI-X vector ctrl writes to
+ device model
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+QEMU needs to know whether clearing maskbit of a vector is really
+clearing, or was already cleared before. Currently Xen sends only
+clearing that bit to the device model, but not setting it, so QEMU
+cannot detect it. Because of that, QEMU is working this around by
+checking via /dev/mem, but that isn't the proper approach.
+
+Give all necessary information to QEMU by passing all ctrl writes,
+including masking a vector. Advertise the new behavior via
+XENVER_get_features, so QEMU can know it doesn't need to access /dev/mem
+anymore.
+
+While this commit doesn't move the whole maskbit handling to QEMU (as
+discussed on xen-devel as one of the possibilities), it is a necessary
+first step anyway. Including telling QEMU it will get all the required
+information to do so. The actual implementation would need to include:
+ - a hypercall for QEMU to control just maskbit (without (re)binding the
+   interrupt again
+ - a methor for QEMU to tell Xen it will actually do the work
+Those are not part of this series.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+I did not added any control to enable/disable this new behavior (as
+Roget have suggested for possible non-QEMU ioreqs). And especially not
+as part of XEN_DMOP_get_ioreq_server_info, as the behavior isn't really
+per-ioreq-server but at best per-device (or system-wide, as it's
+currently done). I don't see how the new behavior could be problematic
+for some existing ioreq server (they already received writes to those
+addresses, just not all of them), but if that's really necessary, I can
+probably add a command line option to restore previous behavior
+system-wide.
+
+Changes in v4:
+- ignore unaligned writes with X86EMUL_OKAY
+- restructure the code to forward all writes in _msixtbl_write() instead
+  of manipulating return value of msixtbl_write() - this makes
+  WRITE_LEN4_COMPLETION special case unnecessary
+- advertise the changed behavior via XENVER_get_features instead of DMOP
+v3:
+ - advertise changed behavior in XEN_DMOP_get_ioreq_server_info - make
+   "flags" parameter IN/OUT
+ - move len check back to msixtbl_write() - will be needed there anyway
+   in a later patch
+v2:
+ - passthrough quad writes to emulator too (Jan)
+ - (ab)use len==0 for write len=4 completion (Jan), but add descriptive
+   #define for this magic value
+---
+ xen/arch/x86/hvm/vmsi.c        | 27 ++++++++++++++++++++++-----
+ xen/common/ioreq.c             |  9 +++++++--
+ xen/common/kernel.c            |  1 +
+ xen/include/public/features.h  |  8 ++++++++
+ xen/include/public/hvm/dm_op.h | 12 ++++++++----
+ 5 files changed, 46 insertions(+), 11 deletions(-)
+
+diff --git a/xen/arch/x86/hvm/vmsi.c b/xen/arch/x86/hvm/vmsi.c
+index 128f236362..356a8d7a76 100644
+--- a/xen/arch/x86/hvm/vmsi.c
++++ b/xen/arch/x86/hvm/vmsi.c
+@@ -272,6 +272,14 @@ out:
+     return r;
+ }
+ 
++/*
++ * This function returns X86EMUL_UNHANDLEABLE even if write is properly
++ * handled, to propagate it to the device model (so it can keep its internal
++ * state in sync).
++ * len==0 means really len==4, but as a write completion that will return
++ * X86EMUL_OKAY on successful processing. Use WRITE_LEN4_COMPLETION to make it
++ * less confusing.
++ */
+ static int msixtbl_write(struct vcpu *v, unsigned long address,
+                          unsigned int len, unsigned long val)
+ {
+@@ -283,8 +291,8 @@ static int msixtbl_write(struct vcpu *v, unsigned long address,
+     unsigned long flags;
+     struct irq_desc *desc;
+ 
+-    if ( (len != 4 && len != 8) || (address & (len - 1)) )
+-        return r;
++    if ( !IS_ALIGNED(address, len) )
++        return X86EMUL_OKAY;
+ 
+     rcu_read_lock(&msixtbl_rcu_lock);
+ 
+@@ -345,8 +353,7 @@ static int msixtbl_write(struct vcpu *v, unsigned long address,
+ 
+ unlock:
+     spin_unlock_irqrestore(&desc->lock, flags);
+-    if ( len == 4 )
+-        r = X86EMUL_OKAY;
++    r = X86EMUL_OKAY;
+ 
+ out:
+     rcu_read_unlock(&msixtbl_rcu_lock);
+@@ -357,7 +364,17 @@ static int cf_check _msixtbl_write(
+     const struct hvm_io_handler *handler, uint64_t address, uint32_t len,
+     uint64_t val)
+ {
+-    return msixtbl_write(current, address, len, val);
++    /* ignore invalid length or unaligned writes */
++    if ( len != 4 && len != 8 || !IS_ALIGNED(address, len) )
++        return X86EMUL_OKAY;
++
++    /*
++     * This function returns X86EMUL_UNHANDLEABLE even if write is properly
++     * handled, to propagate it to the device model (so it can keep its
++     * internal state in sync).
++     */
++    msixtbl_write(current, address, len, val);
++    return X86EMUL_UNHANDLEABLE;
+ }
+ 
+ static bool cf_check msixtbl_range(
+diff --git a/xen/common/ioreq.c b/xen/common/ioreq.c
+index 62b907f4c4..5d0643bf8d 100644
+--- a/xen/common/ioreq.c
++++ b/xen/common/ioreq.c
+@@ -744,7 +744,8 @@ static int ioreq_server_destroy(struct domain *d, ioservid_t id)
+ static int ioreq_server_get_info(struct domain *d, ioservid_t id,
+                                  unsigned long *ioreq_gfn,
+                                  unsigned long *bufioreq_gfn,
+-                                 evtchn_port_t *bufioreq_port)
++                                 evtchn_port_t *bufioreq_port,
++                                 uint16_t *flags)
+ {
+     struct ioreq_server *s;
+     int rc;
+@@ -780,6 +781,9 @@ static int ioreq_server_get_info(struct domain *d, ioservid_t id,
+             *bufioreq_port = s->bufioreq_evtchn;
+     }
+ 
++    /* Advertise supported features/behaviors. */
++    *flags = XEN_DMOP_all_msix_writes;
++
+     rc = 0;
+ 
+  out:
+@@ -1375,7 +1379,8 @@ int ioreq_server_dm_op(struct xen_dm_op *op, struct domain *d, bool *const_op)
+                                    NULL : (unsigned long *)&data->ioreq_gfn,
+                                    (data->flags & XEN_DMOP_no_gfns) ?
+                                    NULL : (unsigned long *)&data->bufioreq_gfn,
+-                                   &data->bufioreq_port);
++                                   &data->bufioreq_port, &data->flags);
++
+         break;
+     }
+ 
+diff --git a/xen/common/kernel.c b/xen/common/kernel.c
+index e928d0b231..767d00b260 100644
+--- a/xen/common/kernel.c
++++ b/xen/common/kernel.c
+@@ -642,6 +642,7 @@ long do_xen_version(int cmd, XEN_GUEST_HANDLE_PARAM(void) arg)
+                 fi.submap |= (1U << XENFEAT_direct_mapped);
+             else
+                 fi.submap |= (1U << XENFEAT_not_direct_mapped);
++            fi.submap |= (1U << XENFEAT_dm_msix_all_writes);
+             break;
+         default:
+             return -EINVAL;
+diff --git a/xen/include/public/features.h b/xen/include/public/features.h
+index 36936f6a4e..634534827d 100644
+--- a/xen/include/public/features.h
++++ b/xen/include/public/features.h
+@@ -120,6 +120,14 @@
+ #define XENFEAT_runstate_phys_area	  18
+ #define XENFEAT_vcpu_time_phys_area	  19
+ 
++/*
++ * If set, Xen will passthrough all MSI-X vector ctrl writes to device model,
++ * not only those unmasking an entry. This allows device model to properly keep
++ * track of the MSI-X table without having to read it from the device behind
++ * Xen's backs. This information is relevant only for device models.
++ */
++#define XENFEAT_dm_msix_all_writes        20
++
+ #define XENFEAT_NR_SUBMAPS 1
+ 
+ #endif /* __XEN_PUBLIC_FEATURES_H__ */
+diff --git a/xen/include/public/hvm/dm_op.h b/xen/include/public/hvm/dm_op.h
+index fa98551914..b6a2d22aa6 100644
+--- a/xen/include/public/hvm/dm_op.h
++++ b/xen/include/public/hvm/dm_op.h
+@@ -70,7 +70,9 @@ typedef struct xen_dm_op_create_ioreq_server xen_dm_op_create_ioreq_server_t;
+  * not contain XEN_DMOP_no_gfns then these pages will be made available and
+  * the frame numbers passed back in gfns <ioreq_gfn> and <bufioreq_gfn>
+  * respectively. (If the IOREQ Server is not handling buffered emulation
+- * only <ioreq_gfn> will be valid).
++ * only <ioreq_gfn> will be valid). When Xen returns XEN_DMOP_all_msix_writes
++ * flag set, it will notify the IOREQ server about all writes to MSI-X table
++ * (if it's handled by this IOREQ server), not only those clearing a mask bit.
+  *
+  * NOTE: To access the synchronous ioreq structures and buffered ioreq
+  *       ring, it is preferable to use the XENMEM_acquire_resource memory
+@@ -81,11 +83,13 @@ typedef struct xen_dm_op_create_ioreq_server xen_dm_op_create_ioreq_server_t;
+ struct xen_dm_op_get_ioreq_server_info {
+     /* IN - server id */
+     ioservid_t id;
+-    /* IN - flags */
++    /* IN/OUT - flags */
+     uint16_t flags;
+ 
+-#define _XEN_DMOP_no_gfns 0
+-#define XEN_DMOP_no_gfns (1u << _XEN_DMOP_no_gfns)
++#define _XEN_DMOP_no_gfns         0  /* IN */
++#define _XEN_DMOP_all_msix_writes 1  /* OUT */
++#define XEN_DMOP_no_gfns         (1u << _XEN_DMOP_no_gfns)
++#define XEN_DMOP_all_msix_writes (1u << _XEN_DMOP_all_msix_writes)
+ 
+     /* OUT - buffered ioreq port */
+     evtchn_port_t bufioreq_port;
+-- 
+2.43.0
+

--- a/xen/0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch
+++ b/xen/0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch
@@ -1,0 +1,440 @@
+From 308f548ee8f7171d8a34238f3f435dcf861ee499 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Mon, 14 Nov 2022 15:50:46 +0100
+Subject: [PATCH 2/2] x86/hvm: Allow writes to registers on the same page as
+ MSI-X table
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Some devices (notably Intel Wifi 6 AX210 card) keep auxiliary registers
+on the same page as MSI-X table. Device model (especially one in
+stubdomain) cannot really handle those, as direct writes to that page is
+refused (page is on the mmio_ro_ranges list). Instead, extend
+msixtbl_mmio_ops to handle such accesses too.
+
+Doing this, requires correlating write location with guest view
+of MSI-X table address. Since QEMU doesn't map MSI-X table to the guest,
+it requires msixtbl_entry->gtable, which is HVM-only. Similar feature
+for PV would need to be done separately.
+
+This will be also used to read Pending Bit Array, if it lives on the same
+page, making QEMU not needing /dev/mem access at all (especially helpful
+with lockdown enabled in dom0). If PBA lives on another page, QEMU will
+map it to the guest directly.
+If PBA lives on the same page, discard writes and log a message.
+Technically, writes outside of PBA could be allowed, but at this moment
+the precise location of PBA isn't saved, and also no known device abuses
+the spec in this way (at least yet).
+
+To access those registers, msixtbl_mmio_ops need the relevant page
+mapped. MSI handling already has infrastructure for that, using fixmap,
+so try to map first/last page of the MSI-X table (if necessary) and save
+their fixmap indexes. Note that msix_get_fixmap() does reference
+counting and reuses existing mapping, so just call it directly, even if
+the page was mapped before. Also, it uses a specific range of fixmap
+indexes which doesn't include 0, so use 0 as default ("not mapped")
+value - which simplifies code a bit.
+
+GCC gets confused about 'desc' variable:
+
+    arch/x86/hvm/vmsi.c: In function ‘msixtbl_range’:
+    arch/x86/hvm/vmsi.c:553:8: error: ‘desc’ may be used uninitialized [-Werror=maybe-uninitialized]
+      553 |     if ( desc )
+          |        ^
+    arch/x86/hvm/vmsi.c:537:28: note: ‘desc’ was declared here
+      537 |     const struct msi_desc *desc;
+          |                            ^~~~
+
+It's conditional initialization is actually correct (in the case where
+it isn't initialized, function returns early), but to avoid
+build failure initialize it explicitly to NULL anyway.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+Changes in v4:
+- drop same_page parameter of msixtbl_find_entry(), distinguish two
+  cases in relevant callers
+- rename adj_access_table_idx to adj_access_idx
+- code style fixes
+- drop alignment check in adjacent_{read,write}() - all callers already
+  have it earlier
+- delay mapping first/last MSI-X pages until preparing device for a
+  passthrough
+v3:
+ - merge handling into msixtbl_mmio_ops
+ - extend commit message
+v2:
+ - adjust commit message
+ - pass struct domain to msixtbl_page_handler_get_hwaddr()
+ - reduce local variables used only once
+ - log a warning if write is forbidden if MSI-X and PBA lives on the same
+   page
+ - do not passthrough unaligned accesses
+ - handle accesses both before and after MSI-X table
+---
+ xen/arch/x86/hvm/vmsi.c        | 191 +++++++++++++++++++++++++++++++--
+ xen/arch/x86/include/asm/msi.h |   5 +
+ xen/arch/x86/msi.c             |  40 +++++++
+ 3 files changed, 225 insertions(+), 11 deletions(-)
+
+diff --git a/xen/arch/x86/hvm/vmsi.c b/xen/arch/x86/hvm/vmsi.c
+index ebc052b8ea84..e21c09f0f5cb 100644
+--- a/xen/arch/x86/hvm/vmsi.c
++++ b/xen/arch/x86/hvm/vmsi.c
+@@ -180,6 +180,10 @@ static bool msixtbl_initialised(const struct domain *d)
+     return d->arch.hvm.msixtbl_list.next;
+ }
+ 
++/*
++ * Lookup an msixtbl_entry on the same page as given addr. It's up to the
++ * caller to check if address is strictly part of the table - if relevant.
++ */
+ static struct msixtbl_entry *msixtbl_find_entry(
+     struct vcpu *v, unsigned long addr)
+ {
+@@ -187,8 +191,8 @@ static struct msixtbl_entry *msixtbl_find_entry(
+     struct domain *d = v->domain;
+ 
+     list_for_each_entry( entry, &d->arch.hvm.msixtbl_list, list )
+-        if ( addr >= entry->gtable &&
+-             addr < entry->gtable + entry->table_len )
++        if ( PFN_DOWN(addr) >= PFN_DOWN(entry->gtable) &&
++             PFN_DOWN(addr) <= PFN_DOWN(entry->gtable + entry->table_len - 1) )
+             return entry;
+ 
+     return NULL;
+@@ -213,6 +217,131 @@ static struct msi_desc *msixtbl_addr_to_desc(
+     return NULL;
+ }
+ 
++/*
++ * Returns:
++ *  - UINT_MAX if no handling should be done
++ *  - UINT_MAX-1 if write should be discarded
++ *  - a fixmap idx to use for handling
++ */
++#define ADJACENT_DONT_HANDLE UINT_MAX
++#define ADJACENT_DISCARD_WRITE (UINT_MAX - 1)
++static unsigned int adjacent_handle(
++    const struct msixtbl_entry *entry, unsigned long addr, bool write)
++{
++    unsigned int adj_type;
++    const struct arch_msix *msix;
++
++    if ( !entry || !entry->pdev )
++        return ADJACENT_DONT_HANDLE;
++
++    if ( PFN_DOWN(addr) == PFN_DOWN(entry->gtable) && addr < entry->gtable )
++        adj_type = ADJ_IDX_FIRST;
++    else if ( PFN_DOWN(addr) == PFN_DOWN(entry->gtable + entry->table_len - 1) &&
++              addr >= entry->gtable + entry->table_len )
++        adj_type = ADJ_IDX_LAST;
++    else
++        return ADJACENT_DONT_HANDLE;
++
++    msix = entry->pdev->msix;
++    ASSERT(msix);
++
++    if ( !msix->adj_access_idx[adj_type] )
++    {
++        gprintk(XENLOG_WARNING,
++                "Page for adjacent(%d) MSI-X table access not initialized for %pp (addr %#lx, gtable %#lx\n",
++                adj_type, &entry->pdev->sbdf, addr, entry->gtable);
++
++        return ADJACENT_DONT_HANDLE;
++    }
++
++    /* If PBA lives on the same page too, discard writes. */
++    if ( write &&
++         ((adj_type == ADJ_IDX_LAST &&
++           msix->table.last == msix->pba.first) ||
++          (adj_type == ADJ_IDX_FIRST &&
++           msix->table.first == msix->pba.last)) )
++    {
++        gprintk(XENLOG_WARNING,
++                "MSI-X table and PBA of %pp live on the same page, "
++                "writing to other registers there is not implemented\n",
++                &entry->pdev->sbdf);
++        return ADJACENT_DISCARD_WRITE;
++    }
++
++    return msix->adj_access_idx[adj_type];
++}
++
++static int adjacent_read(
++    unsigned int fixmap_idx,
++    paddr_t address, unsigned int len, uint64_t *pval)
++{
++    const void __iomem *hwaddr;
++
++    *pval = ~0UL;
++
++    ASSERT(fixmap_idx != ADJACENT_DISCARD_WRITE);
++
++    hwaddr = fix_to_virt(fixmap_idx) + PAGE_OFFSET(address);
++
++    switch ( len )
++    {
++    case 1:
++        *pval = readb(hwaddr);
++        break;
++
++    case 2:
++        *pval = readw(hwaddr);
++        break;
++
++    case 4:
++        *pval = readl(hwaddr);
++        break;
++
++    case 8:
++        *pval = readq(hwaddr);
++        break;
++
++    default:
++        ASSERT_UNREACHABLE();
++    }
++    return X86EMUL_OKAY;
++}
++
++static int adjacent_write(
++        unsigned int fixmap_idx,
++        uint64_t address, uint32_t len, uint64_t val)
++{
++    void __iomem *hwaddr;
++
++    if ( fixmap_idx == ADJACENT_DISCARD_WRITE )
++        return X86EMUL_OKAY;
++
++    hwaddr = fix_to_virt(fixmap_idx) + PAGE_OFFSET(address);
++
++    switch ( len )
++    {
++    case 1:
++        writeb(val, hwaddr);
++        break;
++
++    case 2:
++        writew(val, hwaddr);
++        break;
++
++    case 4:
++        writel(val, hwaddr);
++        break;
++
++    case 8:
++        writeq(val, hwaddr);
++        break;
++
++    default:
++        ASSERT_UNREACHABLE();
++    }
++    return X86EMUL_OKAY;
++}
++
+ static int cf_check msixtbl_read(
+     const struct hvm_io_handler *handler, uint64_t address, uint32_t len,
+     uint64_t *pval)
+@@ -220,16 +349,31 @@ static int cf_check msixtbl_read(
+     unsigned long offset;
+     struct msixtbl_entry *entry;
+     unsigned int nr_entry, index;
++    unsigned int adjacent_fixmap;
+     int r = X86EMUL_UNHANDLEABLE;
+ 
+-    if ( (len != 4 && len != 8) || (address & (len - 1)) )
++    if ( !IS_ALIGNED(address, len) )
+         return r;
+ 
+     rcu_read_lock(&msixtbl_rcu_lock);
+-
+     entry = msixtbl_find_entry(current, address);
+     if ( !entry )
+         goto out;
++
++    adjacent_fixmap = adjacent_handle(entry, address, false);
++    if ( adjacent_fixmap != ADJACENT_DONT_HANDLE )
++    {
++        r = adjacent_read(adjacent_fixmap, address, len, pval);
++        goto out;
++    }
++
++    if ( address < entry->gtable ||
++         address >= entry->gtable + entry->table_len )
++        goto out;
++
++    if ( len != 4 && len != 8 )
++        goto out;
++
+     offset = address & (PCI_MSIX_ENTRY_SIZE - 1);
+ 
+     if ( offset != PCI_MSIX_ENTRY_VECTOR_CTRL_OFFSET )
+@@ -290,6 +434,7 @@ static int msixtbl_write(struct vcpu *v, unsigned long address,
+     int r = X86EMUL_UNHANDLEABLE;
+     unsigned long flags;
+     struct irq_desc *desc;
++    unsigned int adjacent_fixmap;
+ 
+     if ( !IS_ALIGNED(address, len) )
+         return X86EMUL_OKAY;
+@@ -299,6 +444,19 @@ static int msixtbl_write(struct vcpu *v, unsigned long address,
+     entry = msixtbl_find_entry(v, address);
+     if ( !entry )
+         goto out;
++
++    adjacent_fixmap = adjacent_handle(entry, address, true);
++    if ( adjacent_fixmap != ADJACENT_DONT_HANDLE )
++    {
++        r = adjacent_write(adjacent_fixmap, address, len, val);
++        goto out;
++    }
++    if ( address < entry->gtable ||
++         address >= entry->gtable + entry->table_len )
++        goto out;
++    if ( len != 4 && len != 8 )
++        goto out;
++
+     nr_entry = array_index_nospec(((address - entry->gtable) /
+                                    PCI_MSIX_ENTRY_SIZE),
+                                   MAX_MSIX_TABLE_ENTRIES);
+@@ -364,8 +522,8 @@ static int cf_check _msixtbl_write(
+     const struct hvm_io_handler *handler, uint64_t address, uint32_t len,
+     uint64_t val)
+ {
+-    /* ignore invalid length or unaligned writes */
+-    if ( len != 4 && len != 8 || !IS_ALIGNED(address, len) )
++    /* ignore unaligned writes */
++    if ( !IS_ALIGNED(address, len) )
+         return X86EMUL_OKAY;
+ 
+     /*
+@@ -382,14 +540,22 @@ static bool cf_check msixtbl_range(
+ {
+     struct vcpu *curr = current;
+     unsigned long addr = r->addr;
+-    const struct msi_desc *desc;
++    const struct msixtbl_entry *entry;
++    const struct msi_desc *desc = NULL;
++    unsigned int adjacent_fixmap;
+ 
+     ASSERT(r->type == IOREQ_TYPE_COPY);
+ 
+     rcu_read_lock(&msixtbl_rcu_lock);
+-    desc = msixtbl_addr_to_desc(msixtbl_find_entry(curr, addr), addr);
++    entry = msixtbl_find_entry(curr, addr);
++    adjacent_fixmap = adjacent_handle(entry, addr, false);
++    if ( adjacent_fixmap == ADJACENT_DONT_HANDLE )
++        desc = msixtbl_addr_to_desc(entry, addr);
+     rcu_read_unlock(&msixtbl_rcu_lock);
+ 
++    if ( adjacent_fixmap != ADJACENT_DONT_HANDLE )
++        return 1;
++
+     if ( desc )
+         return 1;
+ 
+@@ -630,12 +796,15 @@ void msix_write_completion(struct vcpu *v)
+          v->arch.hvm.hvm_io.msix_snoop_gpa )
+     {
+         unsigned int token = hvmemul_cache_disable(v);
+-        const struct msi_desc *desc;
++        const struct msi_desc *desc = NULL;
++        const struct msixtbl_entry *entry;
+         uint32_t data;
+ 
+         rcu_read_lock(&msixtbl_rcu_lock);
+-        desc = msixtbl_addr_to_desc(msixtbl_find_entry(v, snoop_addr),
+-                                    snoop_addr);
++        entry = msixtbl_find_entry(v, snoop_addr);
++        if ( entry && snoop_addr >= entry->gtable &&
++                      snoop_addr < entry->gtable + entry->table_len )
++            desc = msixtbl_addr_to_desc(entry, snoop_addr);
+         rcu_read_unlock(&msixtbl_rcu_lock);
+ 
+         if ( desc &&
+diff --git a/xen/arch/x86/include/asm/msi.h b/xen/arch/x86/include/asm/msi.h
+index fe670895eed2..86acae3adc6a 100644
+--- a/xen/arch/x86/include/asm/msi.h
++++ b/xen/arch/x86/include/asm/msi.h
+@@ -229,6 +229,10 @@ struct __packed msg_address {
+                                        PCI_MSIX_ENTRY_SIZE + \
+                                        (~PCI_MSIX_BIRMASK & (PAGE_SIZE - 1)))
+ 
++/* indexes in adj_access_idx[] below */
++#define ADJ_IDX_FIRST 0
++#define ADJ_IDX_LAST  1
++
+ struct arch_msix {
+     unsigned int nr_entries, used_entries;
+     struct {
+@@ -236,6 +240,7 @@ struct arch_msix {
+     } table, pba;
+     int table_refcnt[MAX_MSIX_TABLE_PAGES];
+     int table_idx[MAX_MSIX_TABLE_PAGES];
++    unsigned int adj_access_idx[2];
+     spinlock_t table_lock;
+     bool host_maskall, guest_maskall;
+     domid_t warned;
+diff --git a/xen/arch/x86/msi.c b/xen/arch/x86/msi.c
+index d0bf63df1def..7673c1cffe43 100644
+--- a/xen/arch/x86/msi.c
++++ b/xen/arch/x86/msi.c
+@@ -928,6 +928,36 @@ static int msix_capability_init(struct pci_dev *dev,
+         list_add_tail(&entry->list, &dev->msi_list);
+         *desc = entry;
+     }
++    else
++    {
++        /*
++         * If the MSI-X table doesn't start at the page boundary, map the first page for
++         * passthrough accesses.
++         */
++        if ( PAGE_OFFSET(table_paddr) )
++        {
++            int idx = msix_get_fixmap(msix, table_paddr, table_paddr);
++
++            if ( idx > 0 )
++                msix->adj_access_idx[ADJ_IDX_FIRST] = idx;
++            else
++                gprintk(XENLOG_ERR, "Failed to map first MSI-X table page: %d\n", idx);
++        }
++        /*
++         * If the MSI-X table doesn't end on the page boundary, map the last page
++         * for passthrough accesses.
++         */
++        if ( PAGE_OFFSET(table_paddr + msix->nr_entries * PCI_MSIX_ENTRY_SIZE) )
++        {
++            uint64_t entry_paddr = table_paddr + msix->nr_entries * PCI_MSIX_ENTRY_SIZE;
++            int idx = msix_get_fixmap(msix, table_paddr, entry_paddr);
++
++            if ( idx > 0 )
++                msix->adj_access_idx[ADJ_IDX_LAST] = idx;
++            else
++                gprintk(XENLOG_ERR, "Failed to map last MSI-X table page: %d\n", idx);
++        }
++    }
+ 
+     if ( !msix->used_entries )
+     {
+@@ -1090,6 +1120,16 @@ static void _pci_cleanup_msix(struct arch_msix *msix)
+             WARN();
+         msix->table.first = 0;
+         msix->table.last = 0;
++        if ( msix->adj_access_idx[ADJ_IDX_FIRST] )
++        {
++            msix_put_fixmap(msix, msix->adj_access_idx[ADJ_IDX_FIRST]);
++            msix->adj_access_idx[ADJ_IDX_FIRST] = 0;
++        }
++        if ( msix->adj_access_idx[ADJ_IDX_LAST] )
++        {
++            msix_put_fixmap(msix, msix->adj_access_idx[ADJ_IDX_LAST]);
++            msix->adj_access_idx[ADJ_IDX_LAST] = 0;
++        }
+ 
+         if ( rangeset_remove_range(mmio_ro_ranges, msix->pba.first,
+                                    msix->pba.last) )
+-- 
+2.41.0
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -122,8 +122,11 @@ _feature_patches=(
 	"0618-libxl-Properly-suspend-stubdomains.patch"
 	"0619-libxl-Fix-race-condition-in-domain-suspension.patch"
 	"0620-libxl-Add-additional-domain-suspend-resume-logs.patch"
+	"0625-libxl-Allow-stubdomain-to-control-interupts-of-PCI-d.patch"
 	"0626-Validate-EFI-memory-descriptors.patch"
 	"0630-Drop-ELF-notes-from-non-EFI-binary-too.patch"
+	"0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch"
+	"0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch"
 )
 
 
@@ -178,8 +181,11 @@ _feature_patch_sums=(
 	"e02dcaaef6ed5028e708c4a4eae4baf79a37a2ae70f1d760a91b40874c4959c21e5ea76af30059eab5c203b0ae34fb4f6a470cf81090167821358a532df9eb4e" # 0618-libxl-Properly-suspend-stubdomains.patch
 	"06840486624986b1c096b12436e5225a4f7b19c9831777151a60d64ec59e372bc75dd1a7068dcea2826ae4d43ca160104db0dba42c346b7da09453163d0c57fc" # 0619-libxl-Fix-race-condition-in-domain-suspension.patch
 	"04f0c48d916d201e68c2203fd6ac50857ec8ddc99a0e60754ebe6b22508e45fae9b21725476dfc1639211729aa108f5c49efa79860d6f31d415d89dc5b408634" # 0620-libxl-Add-additional-domain-suspend-resume-logs.patch
+	"03893d596b384796c521e53ab66380b0503a53c0e9bbeeb1c9988508f45eb07b24750dc49c3f0ff65a9e649da492a18020fa67002b62adfb69bb522af7522291" # 0625-libxl-Allow-stubdomain-to-control-interupts-of-PCI-d.patch
 	"e2105aa4f07bc3b9cf2b39ee0dc4e72d1dc3fc99212c126ba2889d79cc07c04ed0d33a0edb405c7ab48575fe225893c1c916ae808cd94dba00a910fd94c15ee8" # 0626-Validate-EFI-memory-descriptors.patch
 	"5e7ebb5ec7ea27b236707b0c761f52a9502c540471989d28dfb577cfadd9e995c09ae6baaae52fc76cd08afba4d04f241483f6c07a501ba445ecfdaa14d0c79e" # 0630-Drop-ELF-notes-from-non-EFI-binary-too.patch
+	"7ec27a84ef901d07700a846135f4f56cd7683989d19b6496cad5eda77705d529367cc915bb77dd10623d0315718d42f15efa701699906c184eaf75995f108a32" # 0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch
+	"7af1939e38d42bc52eb03a5c12143e25bf04949821b30a2a6f098c9d4c2e5c04d621418abe275a0cc38bb92ebd3f6671641f271f4c7130fdb45aec09b732c566" # 0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch
 )
 
 


### PR DESCRIPTION
These patches make PCI passthrough work when using stubdomains.
It also makes Message Signaled Interrupts work in general when using stubdomains.

A later qemu patch depends on this.