### PR TITLE
xen: Enable HWP by default

### DIFF
--- a/xen/0643-cpufreq-enable-HWP-by-default.patch
+++ b/xen/0643-cpufreq-enable-HWP-by-default.patch
@@ -1,0 +1,53 @@
+From 0db5508156e0e4e006f7a61bab083f10bed76a1f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Wed, 1 Feb 2023 21:51:27 +0100
+Subject: [PATCH] cpufreq: enable HWP by default
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ docs/misc/xen-command-line.pandoc | 4 ++--
+ xen/drivers/cpufreq/cpufreq.c     | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/docs/misc/xen-command-line.pandoc b/docs/misc/xen-command-line.pandoc
+index 8e65f8bd18..332cc7a3e3 100644
+--- a/docs/misc/xen-command-line.pandoc
++++ b/docs/misc/xen-command-line.pandoc
+@@ -501,7 +501,7 @@ available support.
+ ### cpufreq
+ > `= none | {{ <boolean> | xen } { [:[powersave|performance|ondemand|userspace][,[<maxfreq>]][,[<minfreq>]]] } [,verbose]} | dom0-kernel | hwp[:[<hdc>][,verbose]]`
+ 
+-> Default: `xen`
++> Default: `hwp`
+ 
+ Indicate where the responsibility for driving power states lies.  Note that the
+ choice of `dom0-kernel` is deprecated and not supported by all Dom0 kernels.
+@@ -513,7 +513,7 @@ choice of `dom0-kernel` is deprecated and not supported by all Dom0 kernels.
+   for `xen`.  It is a boolean for `hwp`.
+ * `hwp` selects Hardware-Controlled Performance States (HWP) on supported Intel
+   hardware.  HWP is a Skylake+ feature which provides better CPU power
+-  management.  The default is disabled.  If `hwp` is selected, but hardware
++  management.  The default is enabled.  If `hwp` is selected, but hardware
+   support is not available, Xen will fallback to cpufreq=xen.
+ * `<hdc>` is a boolean to enable Hardware Duty Cycling (HDC).  HDC enables the
+   processor to autonomously force physical package components into idle state.
+diff --git a/xen/drivers/cpufreq/cpufreq.c b/xen/drivers/cpufreq/cpufreq.c
+index 6e5c400849..353bdc1b81 100644
+--- a/xen/drivers/cpufreq/cpufreq.c
++++ b/xen/drivers/cpufreq/cpufreq.c
+@@ -64,7 +64,7 @@ LIST_HEAD_READ_MOSTLY(cpufreq_governor_list);
+ /* set xen as default cpufreq */
+ enum cpufreq_controller cpufreq_controller = FREQCTL_xen;
+ 
+-enum cpufreq_xen_opt __initdata cpufreq_xen_opts[2] = { CPUFREQ_xen,
++enum cpufreq_xen_opt __initdata cpufreq_xen_opts[2] = { CPUFREQ_hwp,
+                                                         CPUFREQ_none };
+ unsigned int __initdata cpufreq_xen_cnt = 1;
+ 
+-- 
+2.43.0
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -125,6 +125,7 @@ _feature_patches=(
 	"0620-libxl-Add-additional-domain-suspend-resume-logs.patch"
 	"0626-Validate-EFI-memory-descriptors.patch"
 	"0630-Drop-ELF-notes-from-non-EFI-binary-too.patch"
+	"0643-cpufreq-enable-HWP-by-default.patch"
 )
 
 
@@ -182,6 +183,7 @@ _feature_patch_sums=(
 	"04f0c48d916d201e68c2203fd6ac50857ec8ddc99a0e60754ebe6b22508e45fae9b21725476dfc1639211729aa108f5c49efa79860d6f31d415d89dc5b408634" # 0620-libxl-Add-additional-domain-suspend-resume-logs.patch
 	"e2105aa4f07bc3b9cf2b39ee0dc4e72d1dc3fc99212c126ba2889d79cc07c04ed0d33a0edb405c7ab48575fe225893c1c916ae808cd94dba00a910fd94c15ee8" # 0626-Validate-EFI-memory-descriptors.patch
 	"5e7ebb5ec7ea27b236707b0c761f52a9502c540471989d28dfb577cfadd9e995c09ae6baaae52fc76cd08afba4d04f241483f6c07a501ba445ecfdaa14d0c79e" # 0630-Drop-ELF-notes-from-non-EFI-binary-too.patch
+	"ae1be4d3fc8b42210cdf27d383411136e77b1e1009ece8166f081f01d04f80004387b2e30566d3f57817b176aed2d421181804e6160fea3866c000e52f135870" # 0643-cpufreq-enable-HWP-by-default.patch
 )
 
 


### PR DESCRIPTION
Hardware-controlled performance states (HWP) is a Skylake+ feature which provides better CPU power management.
If the feature is enabled it will automatically fall back to the xen governor, which is the previous default.