### PR TITLE
xen: Fix race condition in block hotplug script

### DIFF
--- a/xen/1001-hotplug-store-block-params-for-cleanup.patch
+++ b/xen/1001-hotplug-store-block-params-for-cleanup.patch
@@ -1,0 +1,70 @@
+From 796c78e913d0243dfa24f680f2d02796444d00d1 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Wed, 16 Nov 2022 01:38:52 +0100
+Subject: [PATCH 1001/1018] hotplug: store block params for cleanup
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Use /var/run/xen-hotplug for storing information needed to cleanup devices.
+When called "remove" action - xenstore entriens can be already deleted.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/hotplug/Linux/block | 11 +++++++++--
+ 1 file changed, 9 insertions(+), 2 deletions(-)
+
+diff --git a/tools/hotplug/Linux/block b/tools/hotplug/Linux/block
+index 2691b56951c9..dc4466906e70 100644
+--- a/tools/hotplug/Linux/block
++++ b/tools/hotplug/Linux/block
+@@ -3,6 +3,8 @@
+ dir=$(dirname "$0")
+ . "$dir/block-common.sh"
+ 
++HOTPLUG_STORE="/run/xen-hotplug/${XENBUS_PATH//\//-}"
++
+ expand_dev() {
+   local dev
+   case $1 in
+@@ -256,6 +258,9 @@ case "$command" in
+       # script to be called twice, so just bail.
+       exit 0
+     fi
++    echo $p > "$HOTPLUG_STORE-params"
++    echo $mode > "$HOTPLUG_STORE-mode"
++    echo $truetype > "$HOTPLUG_STORE-type"
+ 
+     FRONTEND_ID=$(xenstore_read "$XENBUS_PATH/frontend-id")
+     FRONTEND_UUID=$(xenstore_read_default \
+@@ -332,6 +337,7 @@ mount it read-write in a guest domain."
+         fi
+         do_or_die losetup $roflag "$loopdev" "$file"
+         xenstore_write "$XENBUS_PATH/node" "$loopdev"
++        echo $loopdev > "$HOTPLUG_STORE-node"
+         write_dev "$loopdev"
+         release_lock "block"
+         exit 0
+@@ -346,6 +352,7 @@ mount it read-write in a guest domain."
+     ;;
+ 
+   remove)
++    truetype=$(cat $HOTPLUG_STORE-type || echo $truetype)
+     case $truetype in
+       phy)
+ 	exit 0
+@@ -353,8 +360,8 @@ mount it read-write in a guest domain."
+ 
+       file)
+         claim_lock "block"
+-        node=$(xenstore_read "$XENBUS_PATH/node")
+-	losetup -d "$node"
++        node=$(cat "$HOTPLUG_STORE-node")
++        losetup -d "$node"
+         release_lock "block"
+ 	exit 0
+ 	;;
+-- 
+2.37.3
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -128,9 +128,10 @@ _feature_patches=(
 	"0625-libxl-Allow-stubdomain-to-control-interupts-of-PCI-d.patch"
 	"0626-Validate-EFI-memory-descriptors.patch"
 	"0630-Drop-ELF-notes-from-non-EFI-binary-too.patch"
+	"0643-cpufreq-enable-HWP-by-default.patch"
 	"0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch"
 	"0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch"
-  "0643-cpufreq-enable-HWP-by-default.patch"
+	"1001-hotplug-store-block-params-for-cleanup.patch"
 )
 
 
@@ -191,9 +192,10 @@ _feature_patch_sums=(
 	"03893d596b384796c521e53ab66380b0503a53c0e9bbeeb1c9988508f45eb07b24750dc49c3f0ff65a9e649da492a18020fa67002b62adfb69bb522af7522291" # 0625-libxl-Allow-stubdomain-to-control-interupts-of-PCI-d.patch
 	"e2105aa4f07bc3b9cf2b39ee0dc4e72d1dc3fc99212c126ba2889d79cc07c04ed0d33a0edb405c7ab48575fe225893c1c916ae808cd94dba00a910fd94c15ee8" # 0626-Validate-EFI-memory-descriptors.patch
 	"5e7ebb5ec7ea27b236707b0c761f52a9502c540471989d28dfb577cfadd9e995c09ae6baaae52fc76cd08afba4d04f241483f6c07a501ba445ecfdaa14d0c79e" # 0630-Drop-ELF-notes-from-non-EFI-binary-too.patch
+	"ae1be4d3fc8b42210cdf27d383411136e77b1e1009ece8166f081f01d04f80004387b2e30566d3f57817b176aed2d421181804e6160fea3866c000e52f135870" # 0643-cpufreq-enable-HWP-by-default.patch
 	"7ec27a84ef901d07700a846135f4f56cd7683989d19b6496cad5eda77705d529367cc915bb77dd10623d0315718d42f15efa701699906c184eaf75995f108a32" # 0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch
 	"7af1939e38d42bc52eb03a5c12143e25bf04949821b30a2a6f098c9d4c2e5c04d621418abe275a0cc38bb92ebd3f6671641f271f4c7130fdb45aec09b732c566" # 0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch
-  "ae1be4d3fc8b42210cdf27d383411136e77b1e1009ece8166f081f01d04f80004387b2e30566d3f57817b176aed2d421181804e6160fea3866c000e52f135870" # 0643-cpufreq-enable-HWP-by-default.patch
+	"7ca8f34d4f37f3ea4b6e69eebba219fd055b42c7964299f54841b1228aa20c0a8ff2b6ba8446801339a9855afa347f0c13cbc50b325135512d775547f14f2def" # 1001-hotplug-store-block-params-for-cleanup.patch
 )
 
 


### PR DESCRIPTION
The block hotplug script has a race condition where the xenstore entries can be deleted before the script called, or during when the script is run. Store the xenstore entries on disk in case they're not present in xenstore anymore.