### PR TITLE
xen: Use xen-blkback by default

### DIFF
--- a/xen/1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch
+++ b/xen/1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch
@@ -1,0 +1,39 @@
+From cb24bc96d6ed8a57ff8ef4a1b2b8fce12194e5c8 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Tue, 21 Apr 2015 03:50:04 +0200
+Subject: [PATCH 1002/1018] libxl: do not start dom0 qemu when not needed
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Use xen-blkback for 'vbd' disk types by default and do not setup vfb+vkb
+when no access method was configured. Then check if qemu is really
+needed.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_disk.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/tools/libs/light/libxl_disk.c b/tools/libs/light/libxl_disk.c
+index ea3623dd6fe5..36b89b63b61a 100644
+--- a/tools/libs/light/libxl_disk.c
++++ b/tools/libs/light/libxl_disk.c
+@@ -56,10 +56,12 @@ static void disk_eject_xswatch_callback(libxl__egc *egc, libxl__ev_xswatch *w,
+             "/local/domain/%d/backend/%" TOSTRING(BACKEND_STRING_SIZE)
+            "[a-z]/%*d/%*d",
+            &disk->backend_domid, backend_type);
+-    if (!strcmp(backend_type, "tap") || !strcmp(backend_type, "vbd")) {
++    if (!strcmp(backend_type, "tap")) {
+         disk->backend = LIBXL_DISK_BACKEND_TAP;
+     } else if (!strcmp(backend_type, "qdisk")) {
+         disk->backend = LIBXL_DISK_BACKEND_QDISK;
++    } else if (!strcmp(backend_type, "vbd")) {
++        disk->backend = LIBXL_DISK_BACKEND_PHY;
+     } else {
+         disk->backend = LIBXL_DISK_BACKEND_UNKNOWN;
+     }
+-- 
+2.37.3
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -128,9 +128,10 @@ _feature_patches=(
 	"0625-libxl-Allow-stubdomain-to-control-interupts-of-PCI-d.patch"
 	"0626-Validate-EFI-memory-descriptors.patch"
 	"0630-Drop-ELF-notes-from-non-EFI-binary-too.patch"
+	"0643-cpufreq-enable-HWP-by-default.patch"
 	"0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch"
 	"0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch"
-  "0643-cpufreq-enable-HWP-by-default.patch"
+	"1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch"
 )
 
 
@@ -191,9 +192,10 @@ _feature_patch_sums=(
 	"03893d596b384796c521e53ab66380b0503a53c0e9bbeeb1c9988508f45eb07b24750dc49c3f0ff65a9e649da492a18020fa67002b62adfb69bb522af7522291" # 0625-libxl-Allow-stubdomain-to-control-interupts-of-PCI-d.patch
 	"e2105aa4f07bc3b9cf2b39ee0dc4e72d1dc3fc99212c126ba2889d79cc07c04ed0d33a0edb405c7ab48575fe225893c1c916ae808cd94dba00a910fd94c15ee8" # 0626-Validate-EFI-memory-descriptors.patch
 	"5e7ebb5ec7ea27b236707b0c761f52a9502c540471989d28dfb577cfadd9e995c09ae6baaae52fc76cd08afba4d04f241483f6c07a501ba445ecfdaa14d0c79e" # 0630-Drop-ELF-notes-from-non-EFI-binary-too.patch
+	"ae1be4d3fc8b42210cdf27d383411136e77b1e1009ece8166f081f01d04f80004387b2e30566d3f57817b176aed2d421181804e6160fea3866c000e52f135870" # 0643-cpufreq-enable-HWP-by-default.patch
 	"7ec27a84ef901d07700a846135f4f56cd7683989d19b6496cad5eda77705d529367cc915bb77dd10623d0315718d42f15efa701699906c184eaf75995f108a32" # 0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch
 	"7af1939e38d42bc52eb03a5c12143e25bf04949821b30a2a6f098c9d4c2e5c04d621418abe275a0cc38bb92ebd3f6671641f271f4c7130fdb45aec09b732c566" # 0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch
-  "ae1be4d3fc8b42210cdf27d383411136e77b1e1009ece8166f081f01d04f80004387b2e30566d3f57817b176aed2d421181804e6160fea3866c000e52f135870" # 0643-cpufreq-enable-HWP-by-default.patch
+	"370d44cbc801d0e814dbd4413ea2e42424a880b5084f9876937b281eb73f6eb46a4807ea765d30d539b7ec41e3eda5fb18aa7f8ca506c32c18c359a91fd80fcf" # 1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch
 )
 
 


### PR DESCRIPTION
Sometimes it's not needed to start qemu for block devices, so don't use it unless we really need it. This improves the security of dom0 and reduces the amount of stubdomains if they're being used.

Might fix the issue you're experiencing in #19.