### PR TITLE
xen: Use EHCI for the tablet USB device

### DIFF
--- a/xen/1006-libxl-use-EHCI-for-providing-tablet-USB-device.patch
+++ b/xen/1006-libxl-use-EHCI-for-providing-tablet-USB-device.patch
@@ -1,0 +1,53 @@
+From 3ceba6a97da58c0ef1c5b8a8e54409de902a2022 Mon Sep 17 00:00:00 2001
+From: alcreator <24826469+alcreator@users.noreply.github.com>
+Date: Mon, 17 Sep 2018 23:01:36 +1000
+Subject: [PATCH 1006/1018] libxl: use EHCI for providing tablet USB device
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Linux guest by default do not enable USB autosuspend for UHCI controller
+emulated by QEMU, which increase idle CPU usage. To avoid guest
+modification, resolve it by switching to EHCI controller, for which
+Linux behave correctly.
+
+Signed-off-by: alcreator <24826469+alcreator@users.noreply.github.com>
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_dm.c | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/tools/libs/light/libxl_dm.c b/tools/libs/light/libxl_dm.c
+index 02da900a6f39..aba36518a9f4 100644
+--- a/tools/libs/light/libxl_dm.c
++++ b/tools/libs/light/libxl_dm.c
+@@ -1463,18 +1463,20 @@ static int libxl__build_device_model_args_new(libxl__gc *gc,
+                 LOGD(ERROR, guest_domid, "Both usbdevice and usbdevice_list set");
+                 return ERROR_INVAL;
+             }
+-            flexarray_append(dm_args, "-usb");
++            flexarray_append_pair(dm_args,
++                                  "-device", "usb-ehci,id=ehci");
+             if (b_info->u.hvm.usbdevice) {
+-                flexarray_vappend(dm_args,
+-                                  "-usbdevice", b_info->u.hvm.usbdevice, NULL);
++                flexarray_vappend(dm_args, "-device",
++                                  GCSPRINTF("usb-%s,bus=ehci.0",
++                                            b_info->u.hvm.usbdevice),
++                                  NULL);
+             } else if (b_info->u.hvm.usbdevice_list) {
+                 char **p;
+                 for (p = b_info->u.hvm.usbdevice_list;
+                      *p;
+                      p++) {
+-                    flexarray_vappend(dm_args,
+-                                      "-usbdevice",
+-                                      *p, NULL);
++                    flexarray_vappend(dm_args, "-device",
++                                      GCSPRINTF("usb-%s,bus=ehci.0", *p), NULL);
+                 }
+             }
+         } else if (b_info->u.hvm.usbversion) {
+-- 
+2.37.3
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -132,6 +132,7 @@ _feature_patches=(
 	"0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch"
 	"0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch"
 	"1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch"
+	"1006-libxl-use-EHCI-for-providing-tablet-USB-device.patch"
 )
 
 
@@ -196,6 +197,7 @@ _feature_patch_sums=(
 	"7ec27a84ef901d07700a846135f4f56cd7683989d19b6496cad5eda77705d529367cc915bb77dd10623d0315718d42f15efa701699906c184eaf75995f108a32" # 0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch
 	"7af1939e38d42bc52eb03a5c12143e25bf04949821b30a2a6f098c9d4c2e5c04d621418abe275a0cc38bb92ebd3f6671641f271f4c7130fdb45aec09b732c566" # 0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch
 	"370d44cbc801d0e814dbd4413ea2e42424a880b5084f9876937b281eb73f6eb46a4807ea765d30d539b7ec41e3eda5fb18aa7f8ca506c32c18c359a91fd80fcf" # 1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch
+	"bbed2c6f3bd333cf9f65cb52315740ce27a31eb45356c49485f44650b9d3f84d45ca1465e813ffe9b3ba5cbdb8e3598da7304a139fb2490db19d2f95e96fc000" # 1006-libxl-use-EHCI-for-providing-tablet-USB-device.patch
 )
 
 


### PR DESCRIPTION
Linux guests by default not do not enable USB autosuspend for UHCI controllers emulated by QEMU. To not increase idle CPU usage use the EHCI controller instead.