### PR TITLE
xen: Allow kernel cmdline without kernel if stubdomains are used

### DIFF
--- a/xen/1007-libxl-allow-kernel-cmdline-without-kernel-if-stubdom.patch
+++ b/xen/1007-libxl-allow-kernel-cmdline-without-kernel-if-stubdom.patch
@@ -1,0 +1,36 @@
+From 0e1ec70e77d62a5f4149f6eca68f8c2239aa289b Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Wed, 16 Nov 2022 01:45:25 +0100
+Subject: [PATCH 1007/1018] libxl: allow kernel cmdline without kernel if
+ stubdomain is used
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Qubes's stubdomain gets the kernel (and initramfs) on a block device for
+direct kernel boot. Allow using standard method of passing kernel
+cmdline in this case too.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_create.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/tools/libs/light/libxl_create.c b/tools/libs/light/libxl_create.c
+index e23d3c866feb..d9937f5edc25 100644
+--- a/tools/libs/light/libxl_create.c
++++ b/tools/libs/light/libxl_create.c
+@@ -182,7 +182,8 @@ int libxl__domain_build_info_setdefault(libxl__gc *gc,
+         /* Check HVM direct boot parameters, we should honour ->ramdisk and
+          * ->cmdline iff ->kernel is set.
+          */
+-        if (!b_info->kernel && (b_info->ramdisk || b_info->cmdline)) {
++        if (!b_info->kernel && (b_info->ramdisk || (b_info->cmdline &&
++            !libxl_defbool_val(b_info->device_model_stubdomain)))) {
+             LOG(ERROR, "direct boot parameters specified but kernel missing");
+             return ERROR_INVAL;
+         }
+-- 
+2.37.3
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -132,6 +132,7 @@ _feature_patches=(
 	"0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch"
 	"0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch"
 	"1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch"
+	"1007-libxl-allow-kernel-cmdline-without-kernel-if-stubdom.patch"
 )
 
 
@@ -196,6 +197,7 @@ _feature_patch_sums=(
 	"7ec27a84ef901d07700a846135f4f56cd7683989d19b6496cad5eda77705d529367cc915bb77dd10623d0315718d42f15efa701699906c184eaf75995f108a32" # 0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch
 	"7af1939e38d42bc52eb03a5c12143e25bf04949821b30a2a6f098c9d4c2e5c04d621418abe275a0cc38bb92ebd3f6671641f271f4c7130fdb45aec09b732c566" # 0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch
 	"370d44cbc801d0e814dbd4413ea2e42424a880b5084f9876937b281eb73f6eb46a4807ea765d30d539b7ec41e3eda5fb18aa7f8ca506c32c18c359a91fd80fcf" # 1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch
+	"02bc6a2feee14cdb40e91a7052f1c87f34b79c442ef483c44d04e5470127cfb47e0069e79aa1c0d063110fe2b568040d3fbc38ccb8fbfeacfe7b7ab7fa53a12a" # 1007-libxl-allow-kernel-cmdline-without-kernel-if-stubdom.patch
 )
 
 


### PR DESCRIPTION
I plan to fork Qemu's linux stubdomain to be a more generalized stubdomain for servers. I don't know if this will be useful at all, but since stubdomains are PV VMs this might actually be useful for us. As far as I can tell stubdomains have to be booted using direct kernel boot. This might be related to libvirt compatibility, in which case it is useful to me.