### PR TITLE
xen: Force emulating read-only disks as SCSI

### DIFF
--- a/xen/1008-libxl-Force-emulating-readonly-disks-as-SCSI.patch
+++ b/xen/1008-libxl-Force-emulating-readonly-disks-as-SCSI.patch
@@ -1,0 +1,41 @@
+From 7febcbd1ad92f899f8b0d5a895db501f37a12382 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Wed, 16 Nov 2022 01:48:34 +0100
+Subject: [PATCH 1008/1018] libxl: Force emulating readonly disks as SCSI
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+IDE and AHCI emulation in qemu-xen does not support read-only disks.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_dm.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/libs/light/libxl_dm.c b/tools/libs/light/libxl_dm.c
+index aba36518a9f4..07839e374bca 100644
+--- a/tools/libs/light/libxl_dm.c
++++ b/tools/libs/light/libxl_dm.c
+@@ -1364,7 +1364,7 @@ static int libxl__build_device_model_args_new(libxl__gc *gc,
+             if (disks[i].is_cdrom) {
+                 continue;
+             }
+-            if (strncmp(disks[i].vdev, "sd", 2) == 0) {
++            if (strncmp(disks[i].vdev, "sd", 2) == 0 || !disks[i].readwrite) {
+                 flexarray_vappend(dm_args, "-device", "lsi53c895a", NULL);
+                 break;
+             }
+@@ -1953,7 +1953,7 @@ static int libxl__build_device_model_args_new(libxl__gc *gc,
+                     colo_mode = LIBXL__COLO_NONE;
+                 }
+ 
+-                if (strncmp(disks[i].vdev, "sd", 2) == 0) {
++                if (strncmp(disks[i].vdev, "sd", 2) == 0 || !disks[i].readwrite) {
+                     const char *drive_id;
+                     if (colo_mode == LIBXL__COLO_SECONDARY) {
+                         drive = libxl__sprintf
+-- 
+2.37.3
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -132,6 +132,7 @@ _feature_patches=(
 	"0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch"
 	"0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch"
 	"1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch"
+	"1008-libxl-Force-emulating-readonly-disks-as-SCSI.patch"
 )
 
 
@@ -196,6 +197,7 @@ _feature_patch_sums=(
 	"7ec27a84ef901d07700a846135f4f56cd7683989d19b6496cad5eda77705d529367cc915bb77dd10623d0315718d42f15efa701699906c184eaf75995f108a32" # 0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch
 	"7af1939e38d42bc52eb03a5c12143e25bf04949821b30a2a6f098c9d4c2e5c04d621418abe275a0cc38bb92ebd3f6671641f271f4c7130fdb45aec09b732c566" # 0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch
 	"370d44cbc801d0e814dbd4413ea2e42424a880b5084f9876937b281eb73f6eb46a4807ea765d30d539b7ec41e3eda5fb18aa7f8ca506c32c18c359a91fd80fcf" # 1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch
+	"819b8d3e756d09625261a5ff46c9b7d4003127b4403268a61d2e66238015e3eb33b8adcc67e7e4943933fdb54cecd21d7527900b398b61d5939e4daee4bd70bb" # 1008-libxl-Force-emulating-readonly-disks-as-SCSI.patch
 )
 
 


### PR DESCRIPTION
QEMU does not support emulating IDE and AHCI as read-only disks.