### PR TITLE
xen: Allow replacing the ESC char on xenconsole backends

### DIFF
--- a/xen/1009-tools-xenconsole-replace-ESC-char-on-xenconsole-outp.patch
+++ b/xen/1009-tools-xenconsole-replace-ESC-char-on-xenconsole-outp.patch
@@ -1,0 +1,154 @@
+From d28479ab8a77a46adbcd1484e0a4091457cf70c0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Sun, 10 Feb 2019 02:11:50 +0100
+Subject: [PATCH 1009/1018] tools/xenconsole: replace ESC char on xenconsole
+ output by default
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+And add --no-replace-escape option to disable it.
+This is done to prevent domU from exploiting hypothetical bug in
+terminal emulator.
+
+Add an -r/--no-replace-escape option to xenconsole client to disable
+replacing ESC. Carry it from xl command through env variable.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/console/client/main.c | 21 ++++++++++++++++++---
+ tools/xl/xl_cmdtable.c      |  1 +
+ tools/xl/xl_console.c       |  8 +++++++-
+ 3 files changed, 26 insertions(+), 4 deletions(-)
+
+diff --git a/tools/console/client/main.c b/tools/console/client/main.c
+index d2dcc3ddca..4660770f34 100644
+--- a/tools/console/client/main.c
++++ b/tools/console/client/main.c
+@@ -77,6 +77,7 @@ static void usage(const char *program) {
+ 	       "  -n, --num N      use console number N\n"
+ 	       "  --type TYPE      console type. must be 'pv', 'serial' or 'vuart'\n"
+ 	       "  --start-notify-fd N file descriptor used to notify parent\n"
++	       "  -r, --no-replace-escape Do not replace ESC character with dot\n"
+ 	       "  --escape E       escape sequence to exit console\n"
+ 	       , program);
+ }
+@@ -175,7 +176,7 @@ static void restore_term(int fd, struct termios *old)
+ }
+ 
+ static int console_loop(int fd, struct xs_handle *xs, char *pty_path,
+-			bool interactive, char escape_character)
++			bool interactive, char escape_character, bool replace_escape)
+ {
+ 	int ret, xs_fd = xs_fileno(xs), max_fd = -1;
+ 
+@@ -249,6 +250,12 @@ static int console_loop(int fd, struct xs_handle *xs, char *pty_path,
+ 				fd = -1;
+ 				continue;
+ 			}
++			if (replace_escape) {
++				int i;
++				for (i = 0; i < len; i++)
++					if (msg[i] == '\033')
++						msg[i] = '.';
++			}
+ 
+ 			if (!write_sync(STDOUT_FILENO, msg, len)) {
+ 				perror("write() failed");
+@@ -325,7 +332,7 @@ int main(int argc, char **argv)
+ {
+ 	struct termios attr;
+ 	int domid;
+-	const char *sopt = "hn:";
++	const char *sopt = "hn:r";
+ 	int ch;
+ 	unsigned int num = 0;
+ 	int opt_ind=0;
+@@ -336,6 +343,7 @@ int main(int argc, char **argv)
+ 		{ "help",    0, 0, 'h' },
+ 		{ "start-notify-fd", 1, 0, 's' },
+ 		{ "interactive", 0, 0, 'i' },
++		{ "no-replace-escape", 0, 0, 'r' },
+ 		{ "escape",  1, 0, 'e' },
+ 		{ 0 },
+ 
+@@ -346,9 +354,13 @@ int main(int argc, char **argv)
+ 	char *end;
+ 	console_type type = CONSOLE_INVAL;
+ 	bool interactive = 0;
++	bool replace_escape = 1;
+ 	const char *console_names = "serial, pv, vuart";
+ 	char escape_character = DEFAULT_ESCAPE_CHARACTER;
+ 
++	if (getenv("XEN_CONSOLE_REPLACE_ESCAPE"))
++		replace_escape = atoi(getenv("XEN_CONSOLE_REPLACE_ESCAPE"));
++
+ 	while((ch = getopt_long(argc, argv, sopt, lopt, &opt_ind)) != -1) {
+ 		switch(ch) {
+ 		case 'h':
+@@ -388,6 +400,9 @@ int main(int argc, char **argv)
+ 				exit(EINVAL);
+ 			}
+ 			break;
++		case 'r':
++			replace_escape = 0;
++			break;
+ 		default:
+ 			fprintf(stderr, "Invalid argument\n");
+ 			fprintf(stderr, "Try `%s --help' for more information.\n", 
+@@ -506,7 +521,7 @@ int main(int argc, char **argv)
+ 		close(start_notify_fd);
+ 	}
+ 
+-	console_loop(spty, xs, path, interactive, escape_character);
++	console_loop(spty, xs, path, interactive, escape_character, replace_escape);
+ 
+ 	free(path);
+ 	free(dom_path);
+diff --git a/tools/xl/xl_cmdtable.c b/tools/xl/xl_cmdtable.c
+index 62bdb2aeaa..8ea8a9e8bb 100644
+--- a/tools/xl/xl_cmdtable.c
++++ b/tools/xl/xl_cmdtable.c
+@@ -142,6 +142,7 @@ const struct cmd_spec cmd_table[] = {
+       "[options] <Domain>\n"
+       "-t <type>       console type, pv , serial or vuart\n"
+       "-n <number>     console number\n"
++      "-r              do not replace ESC character with dot\n"
+       "-e <escape>     escape character"
+     },
+     { "vncviewer",
+diff --git a/tools/xl/xl_console.c b/tools/xl/xl_console.c
+index 5633c6f6f7..b827216552 100644
+--- a/tools/xl/xl_console.c
++++ b/tools/xl/xl_console.c
+@@ -27,10 +27,11 @@ int main_console(int argc, char **argv)
+     uint32_t domid;
+     int opt = 0, num = 0;
+     libxl_console_type type = 0;
++    bool replace_escape = true;
+     const char *console_names = "pv, serial, vuart";
+     char* escape_character = NULL;
+ 
+-    SWITCH_FOREACH_OPT(opt, "n:t:e:", NULL, "console", 1) {
++    SWITCH_FOREACH_OPT(opt, "n:t:r:e:", NULL, "console", 1) {
+     case 't':
+         if (!strcmp(optarg, "pv"))
+             type = LIBXL_CONSOLE_TYPE_PV;
+@@ -49,8 +50,13 @@ int main_console(int argc, char **argv)
+     case 'e':
+         escape_character = optarg;
+         break;
++    case 'r':
++        replace_escape = false;
++        break;
+     }
+ 
++    setenv("XEN_CONSOLE_REPLACE_ESCAPE", replace_escape ? "1" : "0", 1);
++
+     domid = find_domain(argv[optind]);
+     if (!type)
+         libxl_primary_console_exec(ctx, domid, -1, escape_character);
+-- 
+2.43.0
+

--- a/xen/1010-tools-xenconsole-Don-t-replace-ESC-char-by-default.patch
+++ b/xen/1010-tools-xenconsole-Don-t-replace-ESC-char-by-default.patch
@@ -1,0 +1,103 @@
+From d4cbc5688b4a16bc8041d0d36427b723831278af Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Rafa=C3=ABl=20Kooi?=
+ <48814281+RA-Kooi@users.noreply.github.com>
+Date: Sat, 17 Feb 2024 22:29:10 +0100
+Subject: [PATCH] tools/xenconsole: Don't replace ESC char by default
+
+The patch to replace the ESC char by default is generally for the
+paranoid. Think if you're testing malware in a domU. Default to
+compatible behavior.
+---
+ docs/man/xl.1.pod.in        | 7 +++++++
+ tools/console/client/main.c | 6 +++---
+ tools/xl/xl_cmdtable.c      | 2 +-
+ tools/xl/xl_console.c       | 4 ++--
+ 4 files changed, 13 insertions(+), 6 deletions(-)
+
+diff --git a/docs/man/xl.1.pod.in b/docs/man/xl.1.pod.in
+index bed8393473..351f69d6b5 100644
+--- a/docs/man/xl.1.pod.in
++++ b/docs/man/xl.1.pod.in
+@@ -240,6 +240,13 @@ emulated serial for HVM guests and PV console for PV guests.
+ 
+ Connect to console number I<NUM>. Console numbers start from 0.
+ 
++=item I<-r>
++
++Replace the ESC char with a dot. This protects the host from a hypothetical
++exploit being executed by the domU. This does break a lot of terminal tools
++such as less or vim. You don't want this unless you're paranoid or testing
++malware.
++
+ =item I<-e escapechar>
+ 
+ Customize the escape sequence used to detach from the domain console to
+diff --git a/tools/console/client/main.c b/tools/console/client/main.c
+index 4660770f34..8068f0e97c 100644
+--- a/tools/console/client/main.c
++++ b/tools/console/client/main.c
+@@ -77,7 +77,7 @@ static void usage(const char *program) {
+ 	       "  -n, --num N      use console number N\n"
+ 	       "  --type TYPE      console type. must be 'pv', 'serial' or 'vuart'\n"
+ 	       "  --start-notify-fd N file descriptor used to notify parent\n"
+-	       "  -r, --no-replace-escape Do not replace ESC character with dot\n"
++	       "  -r, --replace-escape Replace ESC character with dot\n"
+ 	       "  --escape E       escape sequence to exit console\n"
+ 	       , program);
+ }
+@@ -354,7 +354,7 @@ int main(int argc, char **argv)
+ 	char *end;
+ 	console_type type = CONSOLE_INVAL;
+ 	bool interactive = 0;
+-	bool replace_escape = 1;
++	bool replace_escape = 0;
+ 	const char *console_names = "serial, pv, vuart";
+ 	char escape_character = DEFAULT_ESCAPE_CHARACTER;
+ 
+@@ -401,7 +401,7 @@ int main(int argc, char **argv)
+ 			}
+ 			break;
+ 		case 'r':
+-			replace_escape = 0;
++			replace_escape = 1;
+ 			break;
+ 		default:
+ 			fprintf(stderr, "Invalid argument\n");
+diff --git a/tools/xl/xl_cmdtable.c b/tools/xl/xl_cmdtable.c
+index 8ea8a9e8bb..7893ea6e00 100644
+--- a/tools/xl/xl_cmdtable.c
++++ b/tools/xl/xl_cmdtable.c
+@@ -142,7 +142,7 @@ const struct cmd_spec cmd_table[] = {
+       "[options] <Domain>\n"
+       "-t <type>       console type, pv , serial or vuart\n"
+       "-n <number>     console number\n"
+-      "-r              do not replace ESC character with dot\n"
++      "-r              replace ESC character with dot\n"
+       "-e <escape>     escape character"
+     },
+     { "vncviewer",
+diff --git a/tools/xl/xl_console.c b/tools/xl/xl_console.c
+index b827216552..3ee8dc83e0 100644
+--- a/tools/xl/xl_console.c
++++ b/tools/xl/xl_console.c
+@@ -27,7 +27,7 @@ int main_console(int argc, char **argv)
+     uint32_t domid;
+     int opt = 0, num = 0;
+     libxl_console_type type = 0;
+-    bool replace_escape = true;
++    bool replace_escape = false;
+     const char *console_names = "pv, serial, vuart";
+     char* escape_character = NULL;
+ 
+@@ -51,7 +51,7 @@ int main_console(int argc, char **argv)
+         escape_character = optarg;
+         break;
+     case 'r':
+-        replace_escape = false;
++        replace_escape = true;
+         break;
+     }
+ 
+-- 
+2.44.0
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -132,6 +132,8 @@ _feature_patches=(
 	"0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch"
 	"0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch"
 	"1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch"
+	"1009-tools-xenconsole-replace-ESC-char-on-xenconsole-outp.patch"
+	"1010-tools-xenconsole-Don-t-replace-ESC-char-by-default.patch"
 )
 
 
@@ -196,6 +198,8 @@ _feature_patch_sums=(
 	"7ec27a84ef901d07700a846135f4f56cd7683989d19b6496cad5eda77705d529367cc915bb77dd10623d0315718d42f15efa701699906c184eaf75995f108a32" # 0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch
 	"7af1939e38d42bc52eb03a5c12143e25bf04949821b30a2a6f098c9d4c2e5c04d621418abe275a0cc38bb92ebd3f6671641f271f4c7130fdb45aec09b732c566" # 0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch
 	"370d44cbc801d0e814dbd4413ea2e42424a880b5084f9876937b281eb73f6eb46a4807ea765d30d539b7ec41e3eda5fb18aa7f8ca506c32c18c359a91fd80fcf" # 1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch
+	"983658d2a11de892b84c7d2600fb4b5971d92f054fcef0043e01e5bdeb32c4b57667ddf5b3fa59a29e863b90b71d93f876e3e7a69ad089157b04bdebf09b9482" # 1009-tools-xenconsole-replace-ESC-char-on-xenconsole-outp.patch
+	"79e0d8690370f7d455d891694b86fc90078bf1ceecec11fa68563ac9ccaa68b44377139d8442ddccbf29e5eaa6bc241d8583dc190529b807d32c78987966b3b0" # 1010-tools-xenconsole-Don-t-replace-ESC-char-by-default.patch
 )
 
 


### PR DESCRIPTION
This prevents guests from exploiting a hypothetical bug in the console. This is generally for the paranoid and breaks programs such as less and vim, hence it's disabled by default.