### PR TITLE
xen: Support SLIC and OEM Windows installs

### DIFF
--- a/xen/1014-Additional-support-in-ACPI-builder-to-support-SLIC-a.patch
+++ b/xen/1014-Additional-support-in-ACPI-builder-to-support-SLIC-a.patch
@@ -1,0 +1,183 @@
+From 3b2ac02a9978910d9147916a3b8f87a20c7746d6 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Wed, 16 Nov 2022 02:20:15 +0100
+Subject: [PATCH 1014/1018] Additional support in ACPI builder to support SLIC
+ and OEM installs.
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In order to use Windows OEM install media, the SLIC table must be passed to a
+guest. In addition all the OEM table IDs must match the SLIC or Windows will
+think it is invalid and the install ends up unactivated.
+
+NOTE: The DSDT does not get updated. This was the same in the original patch.
+Not sure why that is but it is being left that way for now since it works w/o
+it.
+
+Ported from qemu-acpi-tables.patch by:
+Ross Philipson, philipsonr@ainfosec.com, 05/05/2015
+
+Copied from OpenXT project.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libacpi/build.c | 106 +++++++++++++++++++++++++++++++++++++++---
+ 1 file changed, 100 insertions(+), 6 deletions(-)
+
+diff --git a/tools/libacpi/build.c b/tools/libacpi/build.c
+index fe2db66a62e6..51de7e37a0f3 100644
+--- a/tools/libacpi/build.c
++++ b/tools/libacpi/build.c
+@@ -340,6 +340,66 @@ static int construct_passthrough_tables(struct acpi_ctxt *ctxt,
+     return nr_added;
+ }
+ 
++static void fixup_headers(struct acpi_header *dest, struct acpi_header *src)
++{
++    char bounce[9];
++
++    if (dest == src)
++        return;
++
++    memset(bounce, 0, 9);
++    memcpy(bounce, dest->oem_id, 6);
++    printf("  Overwriting '%s'   with ", bounce);
++    memset(bounce, 0, 9);
++    memcpy(bounce, src->oem_id, 6);
++    printf("'%s'   in ", bounce);
++    printf("%c%c%c%c's OEM_ID\n",
++           ((char*)(&dest->signature))[0],
++           ((char*)(&dest->signature))[1],
++           ((char*)(&dest->signature))[2],
++           ((char*)(&dest->signature))[3]);
++
++
++    memcpy(dest->oem_id, src->oem_id, 6);
++
++    memset(bounce, 0, 9);
++    memcpy(bounce, dest->oem_table_id, 8);
++    printf("  Overwriting '%s' with ", bounce);
++    memset(bounce, 0, 9);
++    memcpy(bounce, src->oem_table_id, 8);
++    printf("'%s' in ", bounce);
++    printf("%c%c%c%c's OEM_TABLE_ID\n",
++           ((char*)(&dest->signature))[0],
++           ((char*)(&dest->signature))[1],
++           ((char*)(&dest->signature))[2],
++           ((char*)(&dest->signature))[3]);
++
++
++    memcpy(dest->oem_table_id, src->oem_table_id, 8);
++    set_checksum(dest, offsetof(struct acpi_header, checksum), dest->length);
++}
++
++static int is_slic(struct acpi_header *table)
++{
++    printf("  Table (%c%c%c%c) is ",
++           ((char*)(&table->signature))[0],
++           ((char*)(&table->signature))[1],
++           ((char*)(&table->signature))[2],
++           ((char*)(&table->signature))[3]);
++
++
++    if ( ( ((char*)(&table->signature))[0] == 'S' ) &&
++         ( ((char*)(&table->signature))[1] == 'L' ) &&
++         ( ((char*)(&table->signature))[2] == 'I' ) &&
++         ( ((char*)(&table->signature))[3] == 'C' ) ) {
++        printf("SLIC\n");
++        return 1;
++    }
++
++    printf ("NOT SLIC\n");
++    return 0;
++}
++
+ static int construct_secondary_tables(struct acpi_ctxt *ctxt,
+                                       unsigned long *table_ptrs,
+                                       struct acpi_config *config,
+@@ -513,6 +573,8 @@ int acpi_build_tables(struct acpi_ctxt *ctxt, struct acpi_config *config)
+     unsigned long        secondary_tables[ACPI_MAX_SECONDARY_TABLES];
+     int                  nr_secondaries, i;
+     unsigned int         fadt_size;
++    struct acpi_header  *slic_header = NULL;
++    int                  needs_id_fixup = 0;
+ 
+     acpi_info = (struct acpi_info *)config->infop;
+     memset(acpi_info, 0, sizeof(*acpi_info));
+@@ -632,6 +694,27 @@ int acpi_build_tables(struct acpi_ctxt *ctxt, struct acpi_config *config)
+     if ( nr_secondaries < 0 )
+         goto oom;
+ 
++    /* We can only have a SLIC if it was passed through. */
++    if ( config->pt.addr ) {
++        /* Check to see if one of the secondary tables is a SLIC. */
++        for (i = 0; i < nr_secondaries; i++) {
++            if (is_slic((struct acpi_header *)secondary_tables[i])) {
++                slic_header = (struct acpi_header *)secondary_tables[i];
++                needs_id_fixup = 1;
++                break;
++            }
++        }
++    }
++
++    /* If we have a SLIC, patch up the other tables to match it. */
++    if (needs_id_fixup) {
++        for (i = 0; i < nr_secondaries; i++) {
++            fixup_headers((struct acpi_header *)secondary_tables[i], slic_header);
++        }
++        fixup_headers(&fadt_10->header, slic_header);
++        fixup_headers(&fadt->header, slic_header);
++    }
++
+     xsdt = ctxt->mem_ops.alloc(ctxt, sizeof(struct acpi_20_xsdt) + 
+                                sizeof(uint64_t) * nr_secondaries,
+                                16);
+@@ -641,9 +724,13 @@ int acpi_build_tables(struct acpi_ctxt *ctxt, struct acpi_config *config)
+     for ( i = 0; secondary_tables[i]; i++ )
+         xsdt->entry[i+1] = secondary_tables[i];
+     xsdt->header.length = sizeof(struct acpi_header) + (i+1)*sizeof(uint64_t);
+-    set_checksum(xsdt,
+-                 offsetof(struct acpi_header, checksum),
+-                 xsdt->header.length);
++    if (needs_id_fixup) {
++        fixup_headers(&xsdt->header, slic_header);
++    } else {
++        set_checksum(xsdt,
++                     offsetof(struct acpi_header, checksum),
++                     xsdt->header.length);
++    }
+ 
+     rsdt = ctxt->mem_ops.alloc(ctxt, sizeof(struct acpi_20_rsdt) +
+                                sizeof(uint32_t) * nr_secondaries,
+@@ -654,9 +741,13 @@ int acpi_build_tables(struct acpi_ctxt *ctxt, struct acpi_config *config)
+     for ( i = 0; secondary_tables[i]; i++ )
+         rsdt->entry[i+1] = secondary_tables[i];
+     rsdt->header.length = sizeof(struct acpi_header) + (i+1)*sizeof(uint32_t);
+-    set_checksum(rsdt,
+-                 offsetof(struct acpi_header, checksum),
+-                 rsdt->header.length);
++    if (needs_id_fixup) {
++        fixup_headers(&rsdt->header, slic_header);
++    } else {
++        set_checksum(rsdt,
++                     offsetof(struct acpi_header, checksum),
++                     rsdt->header.length);
++    }
+ 
+     /*
+      * Fill in low-memory data structures: acpi_info and RSDP.
+@@ -666,6 +757,9 @@ int acpi_build_tables(struct acpi_ctxt *ctxt, struct acpi_config *config)
+     memcpy(rsdp, &Rsdp, sizeof(struct acpi_20_rsdp));
+     rsdp->rsdt_address = ctxt->mem_ops.v2p(ctxt, rsdt);
+     rsdp->xsdt_address = ctxt->mem_ops.v2p(ctxt, xsdt);
++    if (needs_id_fixup) {
++        memcpy(rsdp->oem_id, slic_header->oem_id, 6);
++    }
+     set_checksum(rsdp,
+                  offsetof(struct acpi_10_rsdp, checksum),
+                  sizeof(struct acpi_10_rsdp));
+-- 
+2.37.3
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -132,6 +132,7 @@ _feature_patches=(
 	"0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch"
 	"0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch"
 	"1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch"
+	"1014-Additional-support-in-ACPI-builder-to-support-SLIC-a.patch"
 )
 
 
@@ -196,6 +197,7 @@ _feature_patch_sums=(
 	"7ec27a84ef901d07700a846135f4f56cd7683989d19b6496cad5eda77705d529367cc915bb77dd10623d0315718d42f15efa701699906c184eaf75995f108a32" # 0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch
 	"7af1939e38d42bc52eb03a5c12143e25bf04949821b30a2a6f098c9d4c2e5c04d621418abe275a0cc38bb92ebd3f6671641f271f4c7130fdb45aec09b732c566" # 0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch
 	"370d44cbc801d0e814dbd4413ea2e42424a880b5084f9876937b281eb73f6eb46a4807ea765d30d539b7ec41e3eda5fb18aa7f8ca506c32c18c359a91fd80fcf" # 1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch
+	"e0097e803f8a5fb249a86af38f888dd1860e8a15317b1bbab198af56efa1423735e9cd91a1931fbbcf07e73ffd3ddecd8f4286f05be150d439e5d7e9812a48bd" # 1014-Additional-support-in-ACPI-builder-to-support-SLIC-a.patch
 )
 
 


### PR DESCRIPTION
In order to use Windows OEM install media, the SLIC table must be passed to the guest. 
I don't know if this pertains to all Windows installers, but I assume it does since Qubes needs this patch.