### PR TITLE
xen: Reduce attack surface

### DIFF
--- a/xen/1016-gnttab-disable-grant-tables-v2-by-default.patch
+++ b/xen/1016-gnttab-disable-grant-tables-v2-by-default.patch
@@ -1,0 +1,32 @@
+From 588952430826123ef62bae4dcd1eb87213c40931 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Wed, 25 Aug 2021 02:41:51 +0200
+Subject: [PATCH 1016/1018] gnttab: disable grant tables v2 by default
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+They are not used anywhere, and are significant attack surface.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ xen/common/grant_table.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xen/common/grant_table.c b/xen/common/grant_table.c
+index ee7cc496b8cb..5a2e2db8ae76 100644
+--- a/xen/common/grant_table.c
++++ b/xen/common/grant_table.c
+@@ -179,7 +179,7 @@ static int cf_check parse_gnttab_max_maptrack_frames(const char *arg)
+ }
+ 
+ #ifndef GNTTAB_MAX_VERSION
+-#define GNTTAB_MAX_VERSION 2
++#define GNTTAB_MAX_VERSION 1
+ #endif
+ 
+ unsigned int __read_mostly opt_gnttab_max_version = GNTTAB_MAX_VERSION;
+-- 
+2.37.3
+

--- a/xen/1017-Disable-TSX-by-default.patch
+++ b/xen/1017-Disable-TSX-by-default.patch
@@ -1,0 +1,68 @@
+From 5f639ce509f4afd696716567ad3c7d076c219102 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Wed, 16 Nov 2022 02:26:12 +0100
+Subject: [PATCH 1017/1018] Disable TSX by default
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Intel is dropping TSX from several platforms instead of fixing
+speculative bugs in it. Lets proactively disable it even if wasn't
+dropped on a specific platform yet.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ xen/arch/x86/tsx.c | 15 ++++++++-------
+ 1 file changed, 8 insertions(+), 7 deletions(-)
+
+diff --git a/xen/arch/x86/tsx.c b/xen/arch/x86/tsx.c
+index fbdd05971c..9fd70d63c1 100644
+--- a/xen/arch/x86/tsx.c
++++ b/xen/arch/x86/tsx.c
+@@ -20,7 +20,7 @@
+  * This option only has any effect on systems presenting a mechanism of
+  * controlling TSX behaviour, and where TSX isn't force-disabled by firmware.
+  */
+-int8_t __read_mostly opt_tsx = -1;
++int8_t __read_mostly opt_tsx = -2;
+ bool __read_mostly rtm_disabled;
+ 
+ static int __init cf_check parse_tsx(const char *s)
+@@ -227,6 +227,13 @@ void tsx_init(void)
+     }
+  done_probe:
+ 
++    /*
++     * Check bottom bit only.  Higher bits are various sentinels.  Performed
++     * unconditionally so tsx=0 hides guest CPUID bits on HSX/BDX even without
++     * MSRs to enforce the restriction.
++     */
++    rtm_disabled = !(opt_tsx & 1);
++
+     /*
+      * Note: MSR_TSX_CTRL is enumerated on TSX-enabled MDS_NO and later parts.
+      * MSR_TSX_FORCE_ABORT is enumerated on TSX-enabled pre-MDS_NO Skylake
+@@ -252,9 +259,6 @@ void tsx_init(void)
+ 
+         rdmsr(MSR_TSX_CTRL, lo, hi);
+ 
+-        /* Check bottom bit only.  Higher bits are various sentinels. */
+-        rtm_disabled = !(opt_tsx & 1);
+-
+         lo &= ~(TSX_CTRL_RTM_DISABLE | TSX_CTRL_CPUID_CLEAR);
+         if ( rtm_disabled )
+             lo |= TSX_CTRL_RTM_DISABLE | TSX_CTRL_CPUID_CLEAR;
+@@ -271,9 +275,6 @@ void tsx_init(void)
+ 
+         rdmsr(MSR_TSX_FORCE_ABORT, lo, hi);
+ 
+-        /* Check bottom bit only.  Higher bits are various sentinels. */
+-        rtm_disabled = !(opt_tsx & 1);
+-
+         lo &= ~(TSX_FORCE_ABORT_RTM | TSX_CPUID_CLEAR | TSX_ENABLE_RTM);
+ 
+         if ( cpu_has_rtm_always_abort )
+-- 
+2.44.0
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -139,6 +139,8 @@ _feature_patches=(
 	"1009-tools-xenconsole-replace-ESC-char-on-xenconsole-outp.patch"
 	"1010-tools-xenconsole-Don-t-replace-ESC-char-by-default.patch"
 	"1014-Additional-support-in-ACPI-builder-to-support-SLIC-a.patch"
+	"1016-gnttab-disable-grant-tables-v2-by-default.patch"
+	"1017-Disable-TSX-by-default.patch"
 	"1018-Fix-IGD-passthrough-with-linux-stubdomain.patch"
 	"1301-xenconsoled-install-xenstore-watch-for-all-supported.patch"
 	"1302-xenconsoled-add-support-for-consoles-using-state-xen.patch"
@@ -217,6 +219,8 @@ _feature_patch_sums=(
 	"983658d2a11de892b84c7d2600fb4b5971d92f054fcef0043e01e5bdeb32c4b57667ddf5b3fa59a29e863b90b71d93f876e3e7a69ad089157b04bdebf09b9482" # 1009-tools-xenconsole-replace-ESC-char-on-xenconsole-outp.patch
 	"79e0d8690370f7d455d891694b86fc90078bf1ceecec11fa68563ac9ccaa68b44377139d8442ddccbf29e5eaa6bc241d8583dc190529b807d32c78987966b3b0" # 1010-tools-xenconsole-Don-t-replace-ESC-char-by-default.patch
 	"e0097e803f8a5fb249a86af38f888dd1860e8a15317b1bbab198af56efa1423735e9cd91a1931fbbcf07e73ffd3ddecd8f4286f05be150d439e5d7e9812a48bd" # 1014-Additional-support-in-ACPI-builder-to-support-SLIC-a.patch
+	"7f058161143baf5aa402f86d78b4199df3455c70b952b8691c05a920181e3bf35df3d614109b2916fb9a5e4e437507c7570f50c417bf3086727d405f323b5ced" # 1016-gnttab-disable-grant-tables-v2-by-default.patch
+	"67aa0996072233a5cd777ec3d366241e3250e96cc4c4773a469c854f2e854929b72a5fa0dd2dc065d1ea451882b8d496b206afffacd9fe029628655727b951d2" # 1017-Disable-TSX-by-default.patch
 	"54448175b503ebbcbeb0dac3b13f4e5e1848caee29040fb449049fa0e1c4efe935a1b1fba976fd5026b2ea1e39f46c335064e601fa370f86441b6dc84f01e0f5" # 1018-Fix-IGD-passthrough-with-linux-stubdomain.patch
 	"62cb1c6f83ce2b0d602c6e3a8194e43f7f88c44a5666af25bdb1952bb28c974979e1da77cec86f4bf417282655880fdfb198a94d9aea6a165ce96b173f492bd4" # 1301-xenconsoled-install-xenstore-watch-for-all-supported.patch
 	"dac3d2f240cd03074c00c6e813132904b7778371b9128e827471e2714e240b5e8095ba3ed901566c467bf9871efb7c02dfa591c1ab45d54db4f81ec1eefa5ecc" # 1302-xenconsoled-add-support-for-consoles-using-state-xen.patch


### PR DESCRIPTION
Disabling grant tables v2 is a significant reduction in attack surface and they're not used anywhere.

TSX is a feature that's being dropped by Intel for having speculative bugs in it. Disable it preemptively.