### PR TITLE
xen: Fix IGD passthrough with linux stubdomains

### DIFF
--- a/xen/1018-Fix-IGD-passthrough-with-linux-stubdomain.patch
+++ b/xen/1018-Fix-IGD-passthrough-with-linux-stubdomain.patch
@@ -1,0 +1,194 @@
+From 0aafce690689818524c98a76bcacf12a76012cf1 Mon Sep 17 00:00:00 2001
+From: Grzegorz Uriasz <gorbak25@gmail.com>
+Date: Thu, 13 Feb 2020 02:30:36 +0000
+Subject: [PATCH 1018/1018] Fix IGD passthrough with linux stubdomain
+
+- Give permissions for VGA IOPORTS
+- Give permission for opregions
+- Map vbios to stubdom
+---
+ tools/libs/light/libxl_pci.c | 152 +++++++++++++++++++++++++++++------
+ 1 file changed, 126 insertions(+), 26 deletions(-)
+
+diff --git a/tools/libs/light/libxl_pci.c b/tools/libs/light/libxl_pci.c
+index ccb80e4e26b0..e16abd5fd2a2 100644
+--- a/tools/libs/light/libxl_pci.c
++++ b/tools/libs/light/libxl_pci.c
+@@ -2577,17 +2577,128 @@ void libxl__device_pci_destroy_all(libxl__egc *egc, uint32_t domid,
+     libxl_device_pci_list_free(pcis, num);
+ }
+ 
++static int libxl__grant_legacy_vga_permissions(libxl__gc *gc, const uint32_t domid) {
++    int ret, i;
++    uint64_t vga_iomem_start = 0xa0000 >> XC_PAGE_SHIFT;
++    uint64_t vga_iomem_npages = 0x20; // vga ram + vbios
++    uint64_t vga_vbios_start = 0xc0000 >> XC_PAGE_SHIFT;
++    uint64_t vga_vbios_npages = 0x20;
++    uint32_t stubdom_domid = libxl_get_stubdom_id(CTX, domid);
++    uint64_t vga_ioport_start[] = {0x3B0, 0x3C0};
++    uint64_t vga_ioport_size[] = {0xC, 0x20};
++
++    // VGA RAM
++    ret = xc_domain_iomem_permission(CTX->xch, stubdom_domid,
++                                     vga_iomem_start, vga_iomem_npages, 1);
++    if (ret < 0) {
++        LOGED(ERROR, domid,
++              "failed to give stubdom%d access to iomem range "
++              "%"PRIx64"-%"PRIx64" for VGA passthru",
++              stubdom_domid,
++              vga_iomem_start, (vga_iomem_start + (vga_iomem_npages << XC_PAGE_SHIFT) - 1));
++        return ret;
++    }
++    ret = xc_domain_iomem_permission(CTX->xch, domid,
++                                     vga_iomem_start, vga_iomem_npages, 1);
++    if (ret < 0) {
++        LOGED(ERROR, domid,
++              "failed to give dom%d access to iomem range "
++              "%"PRIx64"-%"PRIx64" for VGA passthru",
++              domid, vga_iomem_start, (vga_iomem_start + (vga_iomem_npages << XC_PAGE_SHIFT) - 1));
++        return ret;
++    }
++
++    // VGA ROM
++    ret = xc_domain_memory_mapping(CTX->xch, stubdom_domid, vga_vbios_start, vga_vbios_start, vga_vbios_npages, DPCI_ADD_MAPPING);
++    if (ret < 0) {
++        LOGED(ERROR, domid, "failed to map VBIOS to stubdom%d", stubdom_domid);
++        return ret;
++    }
++
++    // VGA IOPORTS
++    for (i = 0 ; i < 2 ; i++) {
++        ret = xc_domain_ioport_permission(CTX->xch, stubdom_domid,
++                                          vga_ioport_start[i], vga_ioport_size[i], 1);
++        if (ret < 0) {
++            LOGED(ERROR, domid,
++                  "failed to give stubdom%d access to ioport range "
++                  "%"PRIx64"-%"PRIx64" for VGA passthru",
++                  stubdom_domid,
++                  vga_ioport_start[i], (vga_ioport_start[i] + vga_ioport_size[i] - 1));
++            return ret;
++        }
++        ret = xc_domain_ioport_permission(CTX->xch, domid,
++                                          vga_ioport_start[i], vga_ioport_size[i], 1);
++        if (ret < 0) {
++            LOGED(ERROR, domid,
++                  "failed to give dom%d access to ioport range "
++                  "%"PRIx64"-%"PRIx64" for VGA passthru",
++                  domid, vga_ioport_start[i], (vga_ioport_start[i] + vga_ioport_size[i] - 1));
++            return ret;
++        }
++    }
++
++    return 0;
++}
++
++static int libxl__grant_igd_opregion_permission(libxl__gc *gc, const uint32_t domid) {
++    char* sysfs_path;
++    FILE* f;
++    uint32_t igd_host_opregion;
++    int ret = 0;
++    uint32_t stubdom_domid = libxl_get_stubdom_id(CTX, domid);
++
++    sysfs_path = GCSPRINTF(SYSFS_PCI_DEV"/"PCI_BDF"/config", 0, 0, 2, 0);
++    f = fopen(sysfs_path, "r");
++    if (!f) {
++        LOGED(ERROR, domid, "Unable to access IGD config space");
++        return ERROR_FAIL;
++    }
++
++    ret = fseek(f, 0xfc, SEEK_SET);
++    if (ret < 0) {
++        LOGED(ERROR, domid, "Unable to lseek in PCI config space");
++        goto out;
++    }
++
++    ret = fread((void*)&igd_host_opregion, 4, 1, f);
++    if (ret < 0) {
++        LOGED(ERROR, domid, "Unable to read opregion register");
++        goto out;
++    }
++
++    ret = xc_domain_iomem_permission(CTX->xch, stubdom_domid,
++                                     (unsigned long)(igd_host_opregion >> XC_PAGE_SHIFT), 0x3, 1);
++    if (ret < 0) {
++        LOGED(ERROR, domid,
++              "failed to give stubdom%d access to %"PRIx32" opregions for igd passthrough", stubdom_domid, igd_host_opregion);
++        goto out;
++    }
++
++    ret = xc_domain_iomem_permission(CTX->xch, domid,
++                                     (unsigned long)(igd_host_opregion >> XC_PAGE_SHIFT), 0x3, 1);
++    if (ret < 0) {
++        LOGED(ERROR, domid,
++              "failed to give dom%d access to %"PRIx32" opregions for igd passthrough", domid, igd_host_opregion);
++        goto out;
++    }
++
++    out:
++    if(f)
++        fclose(f);
++    return ret;
++}
++
+ int libxl__grant_vga_iomem_permission(libxl__gc *gc, const uint32_t domid,
+                                       libxl_domain_config *const d_config)
+ {
+-    int i, ret;
++    int i, ret = 0;
++    bool vga_found = false, igd_found = false;
+ 
+     if (!libxl_defbool_val(d_config->b_info.u.hvm.gfx_passthru))
+         return 0;
+ 
+-    for (i = 0 ; i < d_config->num_pcidevs ; i++) {
+-        uint64_t vga_iomem_start = 0xa0000 >> XC_PAGE_SHIFT;
+-        uint32_t stubdom_domid;
++    for (i = 0 ; i < d_config->num_pcidevs && !igd_found ; i++) {
+         libxl_device_pci *pci = &d_config->pcidevs[i];
+         unsigned long pci_device_class;
+ 
+@@ -2596,30 +2707,19 @@ int libxl__grant_vga_iomem_permission(libxl__gc *gc, const uint32_t domid,
+         if (pci_device_class != 0x030000) /* VGA class */
+             continue;
+ 
+-        stubdom_domid = libxl_get_stubdom_id(CTX, domid);
+-        ret = xc_domain_iomem_permission(CTX->xch, stubdom_domid,
+-                                         vga_iomem_start, 0x20, 1);
+-        if (ret < 0) {
+-            LOGED(ERROR, domid,
+-                  "failed to give stubdom%d access to iomem range "
+-                  "%"PRIx64"-%"PRIx64" for VGA passthru",
+-                  stubdom_domid,
+-                  vga_iomem_start, (vga_iomem_start + 0x20 - 1));
+-            return ret;
+-        }
+-        ret = xc_domain_iomem_permission(CTX->xch, domid,
+-                                         vga_iomem_start, 0x20, 1);
+-        if (ret < 0) {
+-            LOGED(ERROR, domid,
+-                  "failed to give dom%d access to iomem range "
+-                  "%"PRIx64"-%"PRIx64" for VGA passthru",
+-                  domid, vga_iomem_start, (vga_iomem_start + 0x20 - 1));
+-            return ret;
+-        }
+-        break;
++        vga_found = true;
++        if (pci->bus == 0 && pci->dev == 2 && pci->func == 0)
++            igd_found = true;
+     }
+ 
+-    return 0;
++    if (vga_found)
++        ret = libxl__grant_legacy_vga_permissions(gc, domid);
++    if (ret < 0)
++        return ret;
++    if (igd_found)
++        ret = libxl__grant_igd_opregion_permission(gc, domid);
++
++    return ret;
+ }
+ 
+ static int libxl_device_pci_compare(const libxl_device_pci *d1,
+-- 
+2.37.3
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -132,6 +132,7 @@ _feature_patches=(
 	"0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch"
 	"0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch"
 	"1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch"
+	"1018-Fix-IGD-passthrough-with-linux-stubdomain.patch"
 )
 
 
@@ -196,6 +197,7 @@ _feature_patch_sums=(
 	"7ec27a84ef901d07700a846135f4f56cd7683989d19b6496cad5eda77705d529367cc915bb77dd10623d0315718d42f15efa701699906c184eaf75995f108a32" # 0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch
 	"7af1939e38d42bc52eb03a5c12143e25bf04949821b30a2a6f098c9d4c2e5c04d621418abe275a0cc38bb92ebd3f6671641f271f4c7130fdb45aec09b732c566" # 0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch
 	"370d44cbc801d0e814dbd4413ea2e42424a880b5084f9876937b281eb73f6eb46a4807ea765d30d539b7ec41e3eda5fb18aa7f8ca506c32c18c359a91fd80fcf" # 1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch
+	"54448175b503ebbcbeb0dac3b13f4e5e1848caee29040fb449049fa0e1c4efe935a1b1fba976fd5026b2ea1e39f46c335064e601fa370f86441b6dc84f01e0f5" # 1018-Fix-IGD-passthrough-with-linux-stubdomain.patch
 )
 
 


### PR DESCRIPTION
Linux stubdomains lack the permissions to interact with the GPU. Give the stubdom the appropriate permissions to make this work.