### PR TITLE
xen: Allow up to 4 xenconsole instances per VM

### DIFF
--- a/xen/0624-libxl-do-not-start-qemu-in-dom0-just-for-extra-conso.patch
+++ b/xen/0624-libxl-do-not-start-qemu-in-dom0-just-for-extra-conso.patch
@@ -1,0 +1,43 @@
+From d71c2bb7013e0e5dc68a29672d510584a65d9770 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Wed, 16 Nov 2022 01:28:47 +0100
+Subject: [PATCH 24/26] libxl: do not start qemu in dom0 just for extra
+ consoles
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+We prefer to have broken extra consoles (breaking also saving/restoring HVM to
+a savefile), than running qemu in dom0.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_dm.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/libs/light/libxl_dm.c b/tools/libs/light/libxl_dm.c
+index 03fc9d794a..debd4d8722 100644
+--- a/tools/libs/light/libxl_dm.c
++++ b/tools/libs/light/libxl_dm.c
+@@ -2593,7 +2593,7 @@ static void spawn_stub_launch_dm(libxl__egc *egc,
+      * Until xenconsoled learns how to handle multiple consoles, require qemu
+      * in dom0 to serve consoles for a stubdomain - it require at least 3 of them.
+      */
+-    need_qemu = 1 || libxl__need_xenpv_qemu(gc, &sdss->dm_config);
++    need_qemu = libxl__need_xenpv_qemu(gc, &sdss->dm_config);
+ 
+     for (i = 0; i < num_console; i++) {
+         libxl__device device;
+@@ -2730,7 +2730,7 @@ static void qmp_proxy_spawn_outcome(libxl__egc *egc,
+      * Until xenconsoled learns how to handle multiple consoles, require qemu
+      * in dom0 to serve consoles for a stubdomain - it require at least 3 of them.
+      */
+-    int need_pvqemu = 1 || libxl__need_xenpv_qemu(gc, &sdss->dm_config);
++    int need_pvqemu = libxl__need_xenpv_qemu(gc, &sdss->dm_config);
+ 
+     if (rc) goto out;
+ 
+-- 
+2.44.0
+

--- a/xen/1301-xenconsoled-install-xenstore-watch-for-all-supported.patch
+++ b/xen/1301-xenconsoled-install-xenstore-watch-for-all-supported.patch
@@ -1,0 +1,71 @@
+From 0b2099342073b3d2dcaccce3e01b1689ce697428 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Tue, 7 Aug 2018 04:16:15 +0200
+Subject: [PATCH 1/6] xenconsoled: install xenstore watch for all supported
+ consoles
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Not only for the primary one (/local/domain/<domid>/console path).
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/console/daemon/io.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/tools/console/daemon/io.c b/tools/console/daemon/io.c
+index bb739bdb8c..14488d58e0 100644
+--- a/tools/console/daemon/io.c
++++ b/tools/console/daemon/io.c
+@@ -784,24 +784,24 @@ static int console_create_ring(struct console *con)
+ 	return err;
+ }
+ 
+-static bool watch_domain(struct domain *dom, bool watch)
++static int watch_domain(struct console *con, struct domain *dom, void **data)
+ {
++	bool watch = data;
+ 	char domid_str[3 + MAX_STRLEN(dom->domid)];
+ 	bool success;
+-	struct console *con = &dom->console[0];
+ 
+ 	snprintf(domid_str, sizeof(domid_str), "dom%u", dom->domid);
+ 	if (watch) {
+ 		success = xs_watch(xs, con->xspath, domid_str);
+ 		if (success)
+-			console_iter_int_arg1(dom, console_create_ring);
++			console_create_ring(con);
+ 		else
+ 			xs_unwatch(xs, con->xspath, domid_str);
+ 	} else {
+ 		success = xs_unwatch(xs, con->xspath, domid_str);
+ 	}
+ 
+-	return success;
++	return !success;
+ }
+ 
+ static int console_init(struct console *con, struct domain *dom, void **data)
+@@ -872,7 +872,7 @@ static struct domain *create_domain(int domid)
+ 	if (console_iter_int_arg3(dom, console_init, (void **)&con_type))
+ 		goto out;
+ 
+-	if (!watch_domain(dom, true))
++	if (console_iter_int_arg3(dom, watch_domain, (void**)true))
+ 		goto out;
+ 
+ 	dom->next = dom_head;
+@@ -946,7 +946,7 @@ static void console_close_evtchn(struct console *con)
+ static void shutdown_domain(struct domain *d)
+ {
+ 	d->is_dead = true;
+-	watch_domain(d, false);
++	console_iter_int_arg3(d, watch_domain, (void**)false);
+ 	console_iter_void_arg1(d, console_unmap_interface);
+ 	console_iter_void_arg1(d, console_close_evtchn);
+ }
+-- 
+2.43.0
+

--- a/xen/1302-xenconsoled-add-support-for-consoles-using-state-xen.patch
+++ b/xen/1302-xenconsoled-add-support-for-consoles-using-state-xen.patch
@@ -1,0 +1,193 @@
+From 58be95af7d907d8fd1ea650bcd6dedbd78ca2ea2 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Tue, 7 Aug 2018 04:16:16 +0200
+Subject: [PATCH 2/6] xenconsoled: add support for consoles using 'state'
+ xenstore entry
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Add support for standard xenbus initialization protocol using 'state'
+xenstore entry. It will be necessary for secondary consoles.
+For consoles supporting it, read 'state' entry on the frontend and
+proceed accordingly - either init console or close it. When closing,
+make sure all the in-transit data is flushed (both from shared ring and
+from local buffer), if possible. This is especially important for
+MiniOS-based qemu stubdomain, which closes console just after writing
+device model state to it.
+For consoles without 'state' field behavior is unchanged - on any watch
+event try to connect console, as long as domain is alive.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/console/daemon/io.c | 86 +++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 83 insertions(+), 3 deletions(-)
+
+diff --git a/tools/console/daemon/io.c b/tools/console/daemon/io.c
+index 14488d58e0..5dca0421fb 100644
+--- a/tools/console/daemon/io.c
++++ b/tools/console/daemon/io.c
+@@ -26,6 +26,7 @@
+ #include <xengnttab.h>
+ #include <xenstore.h>
+ #include <xen/io/console.h>
++#include <xen/io/xenbus.h>
+ #include <xen/grant_table.h>
+ 
+ #include <stdlib.h>
+@@ -108,6 +109,7 @@ struct console {
+ 	struct domain *d;
+ 	bool optional;
+ 	bool use_gnttab;
++	bool have_state;
+ };
+ 
+ struct console_type {
+@@ -116,6 +118,7 @@ struct console_type {
+ 	const char *log_suffix;
+ 	bool optional;
+ 	bool use_gnttab;
++	bool have_state;  // uses 'state' xenstore entry
+ };
+ 
+ static struct console_type console_type[] = {
+@@ -155,6 +158,8 @@ typedef void (*VOID_ITER_FUNC_ARG2)(struct console *,  void *);
+ typedef int (*INT_ITER_FUNC_ARG3)(struct console *,
+ 				  struct domain *dom, void **);
+ 
++static void handle_tty_write(struct console *con);
++
+ static inline bool console_enabled(struct console *con)
+ {
+ 	return con->local_port != -1;
+@@ -664,6 +669,20 @@ static int xs_gather(struct xs_handle *xs, const char *dir, ...)
+ 	return ret;
+ }
+ 
++static void set_backend_state(struct console *con, int state)
++{
++	char path[PATH_MAX], state_str[2], *be_path;
++
++	snprintf(state_str, sizeof(state_str), "%d", state);
++	snprintf(path, sizeof(path), "%s/backend", con->xspath);
++	be_path = xs_read(xs, XBT_NULL, path, NULL);
++	if (be_path) {
++		snprintf(path, sizeof(path), "%s/state", be_path);
++		xs_write(xs, XBT_NULL, path, state_str, 1);
++		free(be_path);
++	}
++}
++
+ static void console_unmap_interface(struct console *con)
+ {
+ 	if (con->interface == NULL)
+@@ -780,10 +799,70 @@ static int console_create_ring(struct console *con)
+ 	if (log_guest && (con->log_fd == -1))
+ 		con->log_fd = create_console_log(con);
+ 
++	/* if everything ok, signal backend readiness, in backend tree */
++	set_backend_state(con, XenbusStateConnected);
++
+  out:
+ 	return err;
+ }
+ 
++/* gracefully close console */
++static int console_close(struct console *con) {
++
++	if (con->interface && con->master_fd != -1 && con->buffer.data) {
++		/* handle remaining data in buffers */
++		buffer_append(con);
++
++		/* write it out, if possible */
++		if (con->master_pollfd_idx != -1) {
++			if (fds[con->master_pollfd_idx].revents &
++					POLLOUT)
++				handle_tty_write(con);
++		}
++	}
++
++	console_close_tty(con);
++	console_unmap_interface(con);
++	set_backend_state(con, XenbusStateClosed);
++
++	return 0;
++}
++
++
++static int handle_console_state(struct console *con) {
++	int err, state;
++
++	if (!con->have_state)
++		return console_create_ring(con);
++
++	err = xs_gather(xs, con->xspath,
++			"state", "%u", &state,
++			NULL);
++	if (err)
++		/* no 'state' entry, assume removal */
++		state = XenbusStateClosed;
++
++	switch (state) {
++		case XenbusStateInitialising:
++		case XenbusStateInitWait:
++			/* wait for frontent init */
++			return 0;
++		case XenbusStateInitialised:
++		case XenbusStateConnected:
++			/* ok, init backend (also on restart) */
++			return console_create_ring(con);
++		case XenbusStateClosing:
++		case XenbusStateClosed:
++			/* close requested */
++			return console_close(con);
++		default:
++			dolog(LOG_ERR,
++			      "Invalid state %d set by console %s of domain %d\n",
++			      state, con->xspath, con->d->domid);
++			return 1;
++	}
++}
++
+ static int watch_domain(struct console *con, struct domain *dom, void **data)
+ {
+ 	bool watch = data;
+@@ -794,7 +873,7 @@ static int watch_domain(struct console *con, struct domain *dom, void **data)
+ 	if (watch) {
+ 		success = xs_watch(xs, con->xspath, domid_str);
+ 		if (success)
+-			console_create_ring(con);
++			handle_console_state(con);
+ 		else
+ 			xs_unwatch(xs, con->xspath, domid_str);
+ 	} else {
+@@ -833,6 +912,7 @@ static int console_init(struct console *con, struct domain *dom, void **data)
+ 	con->log_suffix = (*con_type)->log_suffix;
+ 	con->optional = (*con_type)->optional;
+ 	con->use_gnttab = (*con_type)->use_gnttab;
++	con->have_state = (*con_type)->have_state;
+ 	xsname = (*con_type)->xsname;
+ 	xspath = xs_get_domain_path(xs, dom->domid);
+ 	s = realloc(xspath, strlen(xspath) +
+@@ -1152,7 +1232,7 @@ static void handle_xs(void)
+ 		/* We may get watches firing for domains that have recently
+ 		   been removed, so dom may be NULL here. */
+ 		if (dom && dom->is_dead == false)
+-			console_iter_int_arg1(dom, console_create_ring);
++			console_iter_int_arg1(dom, handle_console_state);
+ 	}
+ 
+ 	free(vec);
+@@ -1381,7 +1461,7 @@ void handle_io(void)
+ 
+ 			console_iter_void_arg2(d, console_evtchn_unmask, (void *)&now);
+ 
+-			console_iter_void_arg2(d, maybe_add_console_evtchn_fd, 
++			console_iter_void_arg2(d, maybe_add_console_evtchn_fd,
+ 					       (void *)&next_timeout);
+ 
+ 			console_iter_void_arg1(d, maybe_add_console_tty_fd);
+-- 
+2.43.0
+

--- a/xen/1303-xenconsoled-make-console_type-use_gnttab-less-confus.patch
+++ b/xen/1303-xenconsoled-make-console_type-use_gnttab-less-confus.patch
@@ -1,0 +1,139 @@
+From b6457b40fab555e1d4e7b1553502bb0e9071d1c4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Tue, 7 Aug 2018 04:16:17 +0200
+Subject: [PATCH 3/6] xenconsoled: make console_type->use_gnttab less confusing
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Before this commit 'use_gnttab' means xenconsoled should first try
+special GNTTAB_RESERVED_CONSOLE entry, and only then fallback to
+ring-ref xenstore entry (being gfn of actual ring).
+In case of secondary consoles, ring-ref entry contains grant table
+reference (not gfn of it), which makes the old meaning of use_gnttab
+really confusing (should be false for such consoles).
+To solve this, add new entry in console_type (and console) structures
+named 'use_reserverd_gnttab' with the old meaning of 'use_gnttab', then
+use 'ues_gnttab' for consoles where ring-ref holds grant table
+reference.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/console/daemon/io.c | 33 ++++++++++++++++++++++-----------
+ 1 file changed, 22 insertions(+), 11 deletions(-)
+
+diff --git a/tools/console/daemon/io.c b/tools/console/daemon/io.c
+index 5dca0421fb..cc4744ca77 100644
+--- a/tools/console/daemon/io.c
++++ b/tools/console/daemon/io.c
+@@ -7,12 +7,12 @@
+  *  This program is free software; you can redistribute it and/or modify
+  *  it under the terms of the GNU General Public License as published by
+  *  the Free Software Foundation; under version 2 of the License.
+- * 
++ *
+  *  This program is distributed in the hope that it will be useful,
+  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  *  GNU General Public License for more details.
+- * 
++ *
+  *  You should have received a copy of the GNU General Public License
+  *  along with this program; If not, see <http://www.gnu.org/licenses/>.
+  */
+@@ -109,6 +109,7 @@ struct console {
+ 	struct domain *d;
+ 	bool optional;
+ 	bool use_gnttab;
++	bool use_reserved_gnttab;
+ 	bool have_state;
+ };
+ 
+@@ -118,6 +119,7 @@ struct console_type {
+ 	const char *log_suffix;
+ 	bool optional;
+ 	bool use_gnttab;
++	bool use_reserved_gnttab;
+ 	bool have_state;  // uses 'state' xenstore entry
+ };
+ 
+@@ -128,6 +130,7 @@ static struct console_type console_type[] = {
+ 		.log_suffix = "",
+ 		.optional = false,
+ 		.use_gnttab = true,
++		.use_reserved_gnttab = true,
+ 	},
+ #if defined(CONFIG_ARM)
+ 	{
+@@ -633,7 +636,7 @@ out:
+ 	console_close_tty(con);
+ 	return 0;
+ }
+- 
++
+ /* Takes tuples of names, scanf-style args, and void **, NULL terminated. */
+ static int xs_gather(struct xs_handle *xs, const char *dir, ...)
+ {
+@@ -687,14 +690,14 @@ static void console_unmap_interface(struct console *con)
+ {
+ 	if (con->interface == NULL)
+ 		return;
+-	if (xgt_handle && con->ring_ref == -1)
++	if (xgt_handle && con->use_gnttab)
+ 		xengnttab_unmap(xgt_handle, con->interface, 1);
+ 	else
+ 		xenforeignmemory_unmap(xfm_handle, con->interface, 1);
+ 	con->interface = NULL;
+ 	con->ring_ref = -1;
+ }
+- 
++
+ static int console_create_ring(struct console *con)
+ {
+ 	int err, remote_port, ring_ref, rc;
+@@ -731,12 +734,19 @@ static int console_create_ring(struct console *con)
+ 
+ 	if (!con->interface && xgt_handle && con->use_gnttab) {
+ 		/* Prefer using grant table */
+-		con->interface = xengnttab_map_grant_ref(xgt_handle,
+-			dom->domid, GNTTAB_RESERVED_CONSOLE,
+-			PROT_READ|PROT_WRITE);
+-		con->ring_ref = -1;
++		if (con->use_reserved_gnttab) {
++			con->interface = xengnttab_map_grant_ref(xgt_handle,
++					dom->domid, GNTTAB_RESERVED_CONSOLE,
++					PROT_READ|PROT_WRITE);
++			con->ring_ref = -1;
++		} else {
++			con->interface = xengnttab_map_grant_ref(xgt_handle,
++					dom->domid, ring_ref,
++					PROT_READ|PROT_WRITE);
++			con->ring_ref = ring_ref;
++		}
+ 	}
+-	if (!con->interface) {
++	if (!con->interface && (!con->use_gnttab || con->use_reserved_gnttab)) {
+ 		xen_pfn_t pfn = ring_ref;
+ 
+ 		/* Fall back to xc_map_foreign_range */
+@@ -772,7 +782,7 @@ static int console_create_ring(struct console *con)
+ 		err = errno;
+ 		goto out;
+ 	}
+- 
++
+ 	rc = xenevtchn_bind_interdomain(con->xce_handle,
+ 		dom->domid, remote_port);
+ 
+@@ -912,6 +922,7 @@ static int console_init(struct console *con, struct domain *dom, void **data)
+ 	con->log_suffix = (*con_type)->log_suffix;
+ 	con->optional = (*con_type)->optional;
+ 	con->use_gnttab = (*con_type)->use_gnttab;
++	con->use_reserved_gnttab = (*con_type)->use_reserved_gnttab;
+ 	con->have_state = (*con_type)->have_state;
+ 	xsname = (*con_type)->xsname;
+ 	xspath = xs_get_domain_path(xs, dom->domid);
+-- 
+2.43.0
+

--- a/xen/1304-xenconsoled-add-support-for-up-to-3-secondary-consol.patch
+++ b/xen/1304-xenconsoled-add-support-for-up-to-3-secondary-consol.patch
@@ -1,0 +1,56 @@
+From 83a4404a7ab89d2ca256943031829ae6a7f2711d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Tue, 7 Aug 2018 04:16:18 +0200
+Subject: [PATCH 4/6] xenconsoled: add support for up to 3 secondary consoles
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Based on previous few commits, this adds basic support for multiple
+consoles in xenconsoled. A static number of them - up to 3 (+ one
+primary).
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/console/daemon/io.c | 24 ++++++++++++++++++++++++
+ 1 file changed, 24 insertions(+)
+
+diff --git a/tools/console/daemon/io.c b/tools/console/daemon/io.c
+index cc4744ca77..3afc44bb67 100644
+--- a/tools/console/daemon/io.c
++++ b/tools/console/daemon/io.c
+@@ -132,6 +132,30 @@ static struct console_type console_type[] = {
+ 		.use_gnttab = true,
+ 		.use_reserved_gnttab = true,
+ 	},
++	{
++		.xsname = "/device/console/1",
++		.ttyname = "tty",
++		.log_suffix = "-con1",
++		.optional = true,
++		.use_gnttab = true,
++		.have_state = true,
++	},
++	{
++		.xsname = "/device/console/2",
++		.ttyname = "tty",
++		.log_suffix = "-con2",
++		.optional = true,
++		.use_gnttab = true,
++		.have_state = true,
++	},
++	{
++		.xsname = "/device/console/3",
++		.ttyname = "tty",
++		.log_suffix = "-con3",
++		.optional = true,
++		.use_gnttab = true,
++		.have_state = true,
++	},
+ #if defined(CONFIG_ARM)
+ 	{
+ 		.xsname = "/vuart/0",
+-- 
+2.43.0
+

--- a/xen/1305-xenconsoled-deduplicate-error-handling.patch
+++ b/xen/1305-xenconsoled-deduplicate-error-handling.patch
@@ -1,0 +1,59 @@
+From f57ad315fb4c606d375ca6cae2161a023da27728 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Tue, 7 Aug 2018 04:16:19 +0200
+Subject: [PATCH 5/6] xenconsoled: deduplicate error handling
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/console/daemon/io.c | 17 +++++++++--------
+ 1 file changed, 9 insertions(+), 8 deletions(-)
+
+diff --git a/tools/console/daemon/io.c b/tools/console/daemon/io.c
+index 3afc44bb67..d194cc68d0 100644
+--- a/tools/console/daemon/io.c
++++ b/tools/console/daemon/io.c
+@@ -812,9 +812,7 @@ static int console_create_ring(struct console *con)
+ 
+ 	if (rc == -1) {
+ 		err = errno;
+-		xenevtchn_close(con->xce_handle);
+-		con->xce_handle = NULL;
+-		goto out;
++		goto err_xce;
+ 	}
+ 	con->local_port = rc;
+ 	con->remote_port = remote_port;
+@@ -822,11 +820,7 @@ static int console_create_ring(struct console *con)
+ 	if (con->master_fd == -1) {
+ 		if (!console_create_tty(con)) {
+ 			err = errno;
+-			xenevtchn_close(con->xce_handle);
+-			con->xce_handle = NULL;
+-			con->local_port = -1;
+-			con->remote_port = -1;
+-			goto out;
++			goto err_xce;
+ 		}
+ 	}
+ 
+@@ -836,6 +830,13 @@ static int console_create_ring(struct console *con)
+ 	/* if everything ok, signal backend readiness, in backend tree */
+ 	set_backend_state(con, XenbusStateConnected);
+ 
++ err_xce:
++	if (err) {
++		xenevtchn_close(con->xce_handle);
++		con->xce_handle = NULL;
++		con->local_port = -1;
++		con->remote_port = -1;
++	}
+  out:
+ 	return err;
+ }
+-- 
+2.43.0
+

--- a/xen/1306-libxl-use-xenconsoled-even-for-multiple-stubdomain-s.patch
+++ b/xen/1306-libxl-use-xenconsoled-even-for-multiple-stubdomain-s.patch
@@ -1,0 +1,48 @@
+From aa124a07c210b214e2fcabb27145d39bc29fa87f Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Marek=20Marczykowski-G=C3=B3recki?=
+ <marmarek@invisiblethingslab.com>
+Date: Tue, 7 Aug 2018 04:16:22 +0200
+Subject: [PATCH 6/6] libxl: use xenconsoled even for multiple stubdomain's
+ consoles
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Since multiple consoles support was added to xenconsoled, use it for
+stubdomain. This makes it possible to have HVM without qemu in dom0 at
+al. As long as no other feature requiring qemu in dom0 is used, like VNC
+or qdisk.
+
+Signed-off-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+---
+ tools/libs/light/libxl_dm.c | 7 +++----
+ 1 file changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/tools/libs/light/libxl_dm.c b/tools/libs/light/libxl_dm.c
+index 5088371439..bd9d4f9945 100644
+--- a/tools/libs/light/libxl_dm.c
++++ b/tools/libs/light/libxl_dm.c
+@@ -2547,7 +2547,9 @@ static void spawn_stub_launch_dm(libxl__egc *egc,
+ 
+     for (i = 0; i < num_console; i++) {
+         console[i].devid = i;
+-        console[i].consback = LIBXL__CONSOLE_BACKEND_IOEMU;
++        /* will be changed back to LIBXL__CONSOLE_BACKEND_IOEMU if qemu
++         * will be in use */
++        console[i].consback = LIBXL__CONSOLE_BACKEND_XENCONSOLED;
+         /* STUBDOM_CONSOLE_LOGGING (console 0) is for minios logging
+          * STUBDOM_CONSOLE_SAVE (console 1) is for writing the save file
+          * STUBDOM_CONSOLE_RESTORE (console 2) is for reading the save file
+@@ -2562,9 +2564,6 @@ static void spawn_stub_launch_dm(libxl__egc *egc,
+                 if (ret) goto out;
+                 console[i].output = GCSPRINTF("file:%s", filename);
+                 free(filename);
+-                /* will be changed back to LIBXL__CONSOLE_BACKEND_IOEMU if qemu
+-                 * will be in use */
+-                console[i].consback = LIBXL__CONSOLE_BACKEND_XENCONSOLED;
+                 break;
+             case STUBDOM_CONSOLE_SAVE:
+                 console[i].output = GCSPRINTF("file:%s",
+-- 
+2.43.0
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -124,6 +124,7 @@ _feature_patches=(
 	"0619-libxl-Fix-race-condition-in-domain-suspension.patch"
 	"0620-libxl-Add-additional-domain-suspend-resume-logs.patch"
 	"0621-libxl-workaround-for-Windows-PV-drivers-removing-con.patch"
+	"0624-libxl-do-not-start-qemu-in-dom0-just-for-extra-conso.patch"
 	"0622-libxl-check-control-feature-before-issuing-pvcontrol.patch"
 	"0625-libxl-Allow-stubdomain-to-control-interupts-of-PCI-d.patch"
 	"0626-Validate-EFI-memory-descriptors.patch"
@@ -132,6 +133,12 @@ _feature_patches=(
 	"0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch"
 	"0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch"
 	"1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch"
+	"1301-xenconsoled-install-xenstore-watch-for-all-supported.patch"
+	"1302-xenconsoled-add-support-for-consoles-using-state-xen.patch"
+	"1303-xenconsoled-make-console_type-use_gnttab-less-confus.patch"
+	"1304-xenconsoled-add-support-for-up-to-3-secondary-consol.patch"
+	"1305-xenconsoled-deduplicate-error-handling.patch"
+	"1306-libxl-use-xenconsoled-even-for-multiple-stubdomain-s.patch"
 )
 
 
@@ -189,6 +196,7 @@ _feature_patch_sums=(
 	"04f0c48d916d201e68c2203fd6ac50857ec8ddc99a0e60754ebe6b22508e45fae9b21725476dfc1639211729aa108f5c49efa79860d6f31d415d89dc5b408634" # 0620-libxl-Add-additional-domain-suspend-resume-logs.patch
 	"31f88b392e8c04929ee63e2b067f93fa015a2c52d0731356f5888a3ab878f2c9c9eb1d21e4fb26a32c7d93c458c7049afac3991a3c6ef34c96f218183da84192" # 0621-libxl-workaround-for-Windows-PV-drivers-removing-con.patch
 	"420eb0da3f241308c787c97c2c5404a16560d83efb6d985c5abd7fc6073917931ed5eca74444f195329202652c559a846e46238d30a2aeafd456b4cdeb0312ff" # 0622-libxl-check-control-feature-before-issuing-pvcontrol.patch
+	"a2fbe50d9dafb34d267a30f09e4afcc63d63751026a955323a2073a0e3551e08ede105c0c2cce9b5724569385249aae894130fd7e0a52b06a3e7e814ef32a59d" # 0624-libxl-do-not-start-qemu-in-dom0-just-for-extra-conso.patch
 	"03893d596b384796c521e53ab66380b0503a53c0e9bbeeb1c9988508f45eb07b24750dc49c3f0ff65a9e649da492a18020fa67002b62adfb69bb522af7522291" # 0625-libxl-Allow-stubdomain-to-control-interupts-of-PCI-d.patch
 	"e2105aa4f07bc3b9cf2b39ee0dc4e72d1dc3fc99212c126ba2889d79cc07c04ed0d33a0edb405c7ab48575fe225893c1c916ae808cd94dba00a910fd94c15ee8" # 0626-Validate-EFI-memory-descriptors.patch
 	"5e7ebb5ec7ea27b236707b0c761f52a9502c540471989d28dfb577cfadd9e995c09ae6baaae52fc76cd08afba4d04f241483f6c07a501ba445ecfdaa14d0c79e" # 0630-Drop-ELF-notes-from-non-EFI-binary-too.patch
@@ -196,6 +204,12 @@ _feature_patch_sums=(
 	"7ec27a84ef901d07700a846135f4f56cd7683989d19b6496cad5eda77705d529367cc915bb77dd10623d0315718d42f15efa701699906c184eaf75995f108a32" # 0651-x86-msi-passthrough-all-MSI-X-vector-ctrl-writes-to-.patch
 	"7af1939e38d42bc52eb03a5c12143e25bf04949821b30a2a6f098c9d4c2e5c04d621418abe275a0cc38bb92ebd3f6671641f271f4c7130fdb45aec09b732c566" # 0652-x86-hvm-Allow-writes-to-registers-on-the-same-page-a.patch
 	"370d44cbc801d0e814dbd4413ea2e42424a880b5084f9876937b281eb73f6eb46a4807ea765d30d539b7ec41e3eda5fb18aa7f8ca506c32c18c359a91fd80fcf" # 1002-libxl-do-not-start-dom0-qemu-when-not-needed.patch
+	"62cb1c6f83ce2b0d602c6e3a8194e43f7f88c44a5666af25bdb1952bb28c974979e1da77cec86f4bf417282655880fdfb198a94d9aea6a165ce96b173f492bd4" # 1301-xenconsoled-install-xenstore-watch-for-all-supported.patch
+	"dac3d2f240cd03074c00c6e813132904b7778371b9128e827471e2714e240b5e8095ba3ed901566c467bf9871efb7c02dfa591c1ab45d54db4f81ec1eefa5ecc" # 1302-xenconsoled-add-support-for-consoles-using-state-xen.patch
+	"5c796c990192d3f37247edb4861a4b20569c4e3e084404af8f278a356365a3c7ae212896d186ae51aa2b7960c1bd8c45602df0594036eb73fa15577e3bf0832c" # 1303-xenconsoled-make-console_type-use_gnttab-less-confus.patch
+	"f0e6381f1204b7741074c5eda0a36a36ea853509d0c7b3824e0bf435e42fcfc299245eb6afb2e57b3408f28fb780e53a83d3033cecfa13a875275985e3480ad0" # 1304-xenconsoled-add-support-for-up-to-3-secondary-consol.patch
+	"aaf5c08a47005d914aa69ab7ca89773d25c125f6d3d89d0626c519feee0d0207bb19f6a19e869d0fc4353a403d9680aa01f5213ac6d27327ba749095b0a77590" # 1305-xenconsoled-deduplicate-error-handling.patch
+	"b3160b15e9afa712086db2479998d18d44fe540f11fb8d0f0e8c7d3a4e19a7aca3a56f8fcfca4c354d4e88fd4becf18a529e48006ad0792a6c23a49a63e14aa1" # 1306-libxl-use-xenconsoled-even-for-multiple-stubdomain-s.patch
 )
 
 


### PR DESCRIPTION
Normally a VM only gets a single xenconsole assigned to it and the rest are provided by QEMU. In order to get rid of QEMU being used in dom0 for the consoles we instead extend xenconsoled to support 4 consoles per VM. I think this is a good compromise between security and usability. Do note that when stubdomains are used some of the consoles will be used up by the stubdomains.