### PR TITLE
xen: Workaround c-states bugs in Nehalem and Westmere CPUs

### DIFF
--- a/xen/0002-intel-Workaround-Nehalem-and-Westmere-C-states-bugs.patch
+++ b/xen/0002-intel-Workaround-Nehalem-and-Westmere-C-states-bugs.patch
@@ -1,0 +1,67 @@
+From 932bce4cecb7905649872b47a4a87d40ae9f7660 Mon Sep 17 00:00:00 2001
+From: Malcolm Crossley <malcolm.crossley@citrix.com>
+Date: Wed, 7 Feb 2024 04:53:50 +0100
+Subject: [PATCH 02/18] intel: Workaround Nehalem and Westmere C-states bugs
+
+CA-49885: Restrict Intel Nehalem and Westmere class processors to a maximum
+c-state level of 1 to workaround various Intel errata associated with these
+processors.
+---
+ xen/arch/x86/cpu/intel.c | 34 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 34 insertions(+)
+
+diff --git a/xen/arch/x86/cpu/intel.c b/xen/arch/x86/cpu/intel.c
+index aef8e4506c..d981c44f92 100644
+--- a/xen/arch/x86/cpu/intel.c
++++ b/xen/arch/x86/cpu/intel.c
+@@ -370,6 +370,38 @@ static void probe_c3_errata(const struct cpuinfo_x86 *c)
+     }
+ }
+ 
++/*
++ * Detect Intel Nehalem CPU's with C-states enabled and restrict to C1 due to
++ * Intel Errata BA80, AAK120, AAM108, AAO67, BD59, AAY54
++ */
++static void nehalem_cpu_cstate_workaround(struct cpuinfo_x86 *c)
++{
++    static bool_t nehalem_cstate_errata_workaround_warning = 0;
++
++    if ( c->x86_vendor == X86_VENDOR_INTEL && c->x86 == 6 )
++    {
++        switch ( c->x86_model )
++        {
++        /* Nehalem */
++        case 0x1A:
++        case 0x1E:
++        case 0x1F:
++        case 0x2E:
++        /* Westmere */
++        case 0x25:
++        case 0x2C:
++            if ( !nehalem_cstate_errata_workaround_warning )
++            {
++                printk(XENLOG_WARNING "Disabling C-states C3 and C6 on Nehalem"
++                        " Processors due to errata\n");
++                nehalem_cstate_errata_workaround_warning = 1;
++            }
++            max_cstate = 1;
++            break;
++        }
++    }
++}
++
+ /*
+  * P4 Xeon errata 037 workaround.
+  * Hardware prefetcher may cause stale data to be loaded into the cache.
+@@ -396,6 +428,8 @@ static void Intel_errata_workarounds(struct cpuinfo_x86 *c)
+ 		__set_bit(X86_FEATURE_CLFLUSH_MONITOR, c->x86_capability);
+ 
+ 	probe_c3_errata(c);
++
++	nehalem_cpu_cstate_workaround(c);
+ }
+ 
+ 
+-- 
+2.43.0
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -146,6 +146,7 @@ _feature_patches=(
 	"1304-xenconsoled-add-support-for-up-to-3-secondary-consol.patch"
 	"1305-xenconsoled-deduplicate-error-handling.patch"
 	"1306-libxl-use-xenconsoled-even-for-multiple-stubdomain-s.patch"
+	"0002-intel-Workaround-Nehalem-and-Westmere-C-states-bugs.patch"
 )
 
 
@@ -224,6 +225,7 @@ _feature_patch_sums=(
 	"f0e6381f1204b7741074c5eda0a36a36ea853509d0c7b3824e0bf435e42fcfc299245eb6afb2e57b3408f28fb780e53a83d3033cecfa13a875275985e3480ad0" # 1304-xenconsoled-add-support-for-up-to-3-secondary-consol.patch
 	"aaf5c08a47005d914aa69ab7ca89773d25c125f6d3d89d0626c519feee0d0207bb19f6a19e869d0fc4353a403d9680aa01f5213ac6d27327ba749095b0a77590" # 1305-xenconsoled-deduplicate-error-handling.patch
 	"b3160b15e9afa712086db2479998d18d44fe540f11fb8d0f0e8c7d3a4e19a7aca3a56f8fcfca4c354d4e88fd4becf18a529e48006ad0792a6c23a49a63e14aa1" # 1306-libxl-use-xenconsoled-even-for-multiple-stubdomain-s.patch
+	"0384b29938499d6c281c269ac1adc016a529cacea926dd81b8feb0db00abe80495eb7be86c9f200f2141a0f6a9f25bf7dc440d7e7789db8fd4357a89caaed83b" # 0002-intel-Workaround-Nehalem-and-Westmere-C-states-bugs.patch
 )
 
 


### PR DESCRIPTION
CA-49885: Restrict Intel Nehalem and Westmere class processors to a maximum c-state level of 1 to workaround various Intel errata associated with these processors.