### PR TITLE
xen: Fix GPU passthrough on HP Gen8 devices

### DIFF
--- a/xen/0003-vtd-quirks-Ignore-HP-Gen8-GPU-audio-devices-for-RMRR.patch
+++ b/xen/0003-vtd-quirks-Ignore-HP-Gen8-GPU-audio-devices-for-RMRR.patch
@@ -1,0 +1,98 @@
+From 030eca5409044a1db7a7501e77cb7b615725d82d Mon Sep 17 00:00:00 2001
+From: Malcolm Crossley <malcolm.crossley@citrix.com>
+Date: Wed, 7 Feb 2024 04:56:53 +0100
+Subject: [PATCH 03/18] vtd/quirks: Ignore HP Gen8 GPU audio devices for RMRR
+
+HP Gen8 BIOS incorrectly add GPU audio devices to the RMRR device list.
+This causes domains with GPU devices passthrough to fail to start as the
+RMRR regions conflict with key memory locations in the guest memory map.
+---
+ xen/drivers/passthrough/vtd/dmar.c   |  9 ++++++++
+ xen/drivers/passthrough/vtd/dmar.h   |  1 +
+ xen/drivers/passthrough/vtd/quirks.c | 32 ++++++++++++++++++++++++++++
+ 3 files changed, 42 insertions(+)
+
+diff --git a/xen/drivers/passthrough/vtd/dmar.c b/xen/drivers/passthrough/vtd/dmar.c
+index 07772f178f..13d38f2de5 100644
+--- a/xen/drivers/passthrough/vtd/dmar.c
++++ b/xen/drivers/passthrough/vtd/dmar.c
+@@ -385,6 +385,15 @@ static int __init acpi_parse_dev_scope(
+             break;
+ 
+         case ACPI_DMAR_SCOPE_TYPE_ENDPOINT:
++            if ( !drhd && rmrr_device_quirks(PCI_SBDF(seg, bus, path->dev, path->fn)) )
++            {
++                if ( iommu_verbose )
++                    printk(VTDPREFIX " QUIRK: ignoring %04x:%02x:%02x.%u\n",
++                           seg, bus, path->dev, path->fn);
++                start += acpi_scope->length;
++                continue;
++            }
++
+             if ( iommu_verbose )
+                 printk(VTDPREFIX " endpoint: %pp\n",
+                        &PCI_SBDF(seg, bus, path->dev, path->fn));
+diff --git a/xen/drivers/passthrough/vtd/dmar.h b/xen/drivers/passthrough/vtd/dmar.h
+index a1f2353a51..af0728e337 100644
+--- a/xen/drivers/passthrough/vtd/dmar.h
++++ b/xen/drivers/passthrough/vtd/dmar.h
+@@ -159,5 +159,6 @@ do {                                                               \
+ int vtd_hw_check(void);
+ void disable_pmr(struct vtd_iommu *iommu);
+ int is_igd_drhd(struct acpi_drhd_unit *drhd);
++int rmrr_device_quirks(pci_sbdf_t sbdf);
+ 
+ #endif /* _DMAR_H_ */
+diff --git a/xen/drivers/passthrough/vtd/quirks.c b/xen/drivers/passthrough/vtd/quirks.c
+index 5a56565ea8..ea7d3ee78b 100644
+--- a/xen/drivers/passthrough/vtd/quirks.c
++++ b/xen/drivers/passthrough/vtd/quirks.c
+@@ -29,6 +29,7 @@
+ #include <xen/pci_ids.h>
+ #include <xen/pci_regs.h>
+ #include <xen/keyhandler.h>
++#include <xen/dmi.h>
+ #include <asm/msi.h>
+ #include <asm/irq.h>
+ #include <asm/pci.h>
+@@ -612,6 +613,37 @@ void pci_vtd_quirk(const struct pci_dev *pdev)
+     }
+ }
+ 
++const static struct dmi_system_id __initconstrel rmrr_dmi_quirks[] =
++{
++    {
++        .ident    = "HP Gen 8",
++        .matches  = {
++            DMI_MATCH(DMI_SYS_VENDOR, "HP"),
++            DMI_MATCH(DMI_PRODUCT_NAME,   "Gen8")
++        }
++    },
++    {}
++};
++
++#define PCI_CLASS_AUDIO_DEVICE    0x0403
++
++int __init rmrr_device_quirks(pci_sbdf_t sbdf)
++{
++    static __initdata int8_t match = -1;
++
++    if ( unlikely(match < 0) )
++        match = !!dmi_check_system(rmrr_dmi_quirks);
++    if ( !match )
++        return 0;
++
++    /* Match PCI audio class device not on function 0 */
++    if ( sbdf.fn != 0 &&
++         pci_conf_read16(sbdf, PCI_CLASS_DEVICE) == PCI_CLASS_AUDIO_DEVICE )
++        return 1;
++
++    return 0;
++}
++
+ void __init quirk_iommu_caps(struct vtd_iommu *iommu)
+ {
+     /*
+-- 
+2.43.0
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -146,6 +146,7 @@ _feature_patches=(
 	"1304-xenconsoled-add-support-for-up-to-3-secondary-consol.patch"
 	"1305-xenconsoled-deduplicate-error-handling.patch"
 	"1306-libxl-use-xenconsoled-even-for-multiple-stubdomain-s.patch"
+	"0003-vtd-quirks-Ignore-HP-Gen8-GPU-audio-devices-for-RMRR.patch"
 )
 
 
@@ -224,6 +225,7 @@ _feature_patch_sums=(
 	"f0e6381f1204b7741074c5eda0a36a36ea853509d0c7b3824e0bf435e42fcfc299245eb6afb2e57b3408f28fb780e53a83d3033cecfa13a875275985e3480ad0" # 1304-xenconsoled-add-support-for-up-to-3-secondary-consol.patch
 	"aaf5c08a47005d914aa69ab7ca89773d25c125f6d3d89d0626c519feee0d0207bb19f6a19e869d0fc4353a403d9680aa01f5213ac6d27327ba749095b0a77590" # 1305-xenconsoled-deduplicate-error-handling.patch
 	"b3160b15e9afa712086db2479998d18d44fe540f11fb8d0f0e8c7d3a4e19a7aca3a56f8fcfca4c354d4e88fd4becf18a529e48006ad0792a6c23a49a63e14aa1" # 1306-libxl-use-xenconsoled-even-for-multiple-stubdomain-s.patch
+	"1b3b9bcef20fa3257020656cf3268fe216e7b02ec10d39170b2cf0a5b360ad3f23bad99abb769535fb0bdde86528fc2d7b9e109c93f8fe9fc9bdfc710cc4edb8" # 0003-vtd-quirks-Ignore-HP-Gen8-GPU-audio-devices-for-RMRR.patch
 )
 
 


### PR DESCRIPTION
> HP Gen8 BIOS incorrectly add GPU audio devices to the RMRR device list.
> This causes domains with GPU devices passthrough to fail to start as the
> RMRR regions conflict with key memory locations in the guest memory map.