### PR TITLE
xen: Improve compatibility with JMICRON, Marvell, and TTI devices

### DIFF
--- a/xen/0004-pci-Add-PCI-phantom-functions-to-Xen-based-on-PCI-ve.patch
+++ b/xen/0004-pci-Add-PCI-phantom-functions-to-Xen-based-on-PCI-ve.patch
@@ -1,0 +1,91 @@
+From b865856fffe142f4d00a968d2df10259d7863cb2 Mon Sep 17 00:00:00 2001
+From: Malcolm Crossley <malcolm.crossley@citrix.com>
+Date: Wed, 7 Feb 2024 05:01:24 +0100
+Subject: [PATCH 04/18] pci: Add PCI phantom functions to Xen based on PCI
+ vendor + device ID.
+
+The list of devices to quirk has been taken from Linux kernel quirk list
+---
+ xen/drivers/passthrough/pci.c | 59 +++++++++++++++++++++++++++++++++++
+ 1 file changed, 59 insertions(+)
+
+diff --git a/xen/drivers/passthrough/pci.c b/xen/drivers/passthrough/pci.c
+index e99837b6e1..91b347ca04 100644
+--- a/xen/drivers/passthrough/pci.c
++++ b/xen/drivers/passthrough/pci.c
+@@ -1023,6 +1023,63 @@ void pci_check_disable_device(u16 seg, u8 bus, u8 devfn)
+     pci_conf_write16(pdev->sbdf, PCI_COMMAND, cword & ~PCI_COMMAND_MASTER);
+ }
+ 
++static void quirk_dma_func_phantom(pci_sbdf_t sbdf)
++{
++    struct phantom_dev phantom = {
++        .seg = sbdf.seg,
++        .bus = sbdf.bus,
++        .slot = sbdf.devfn,
++        .stride = 1,
++    };
++
++    phantom_devs[nr_phantom_devs++] = phantom;
++}
++
++static void quirk_scan_pci_device(pci_sbdf_t sbdf)
++{
++    unsigned int device, vendor = pci_conf_read16(sbdf, PCI_VENDOR_ID);
++
++    switch ( vendor )
++    {
++    case 0x1b4b: /* Marvell */
++    case 0x197B: /* JMICRON */
++    case 0x1103: /* TTI */
++        break;
++    default:
++        return;
++    }
++
++    device = pci_conf_read16(sbdf, PCI_DEVICE_ID);
++
++    switch ( vendor )
++    {
++    case 0x1b4b: /* Marvell */
++        switch ( device )
++        {
++        case 0x9120: /* 88SE9123 based controllers */
++        case 0x9123:
++        case 0x9130:
++        case 0x9172:
++        case 0x917a:
++        case 0x91a0:
++        case 0x9230:
++            quirk_dma_func_phantom(sbdf);
++            break;
++        }
++        break;
++
++    case 0x197B: /* JMICRON */
++        if ( device == 0x2393 ) /* JMB388 ESD */
++            quirk_dma_func_phantom(sbdf);
++        break;
++
++    case 0x1103: /* TTI */
++        if ( device == 0x0642 )
++            quirk_dma_func_phantom(sbdf);
++        break;
++    }
++}
++
+ /*
+  * scan pci devices to add all existed PCI devices to alldevs_list,
+  * and setup pci hierarchy in array bus2bridge.
+@@ -1045,6 +1102,8 @@ static int __init cf_check _scan_pci_devices(struct pci_seg *pseg, void *arg)
+                     continue;
+                 }
+ 
++                quirk_scan_pci_device(PCI_SBDF(pseg->nr, bus, dev, func));
++
+                 pdev = alloc_pdev(pseg, bus, PCI_DEVFN(dev, func));
+                 if ( !pdev )
+                 {
+-- 
+2.43.0
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -146,6 +146,7 @@ _feature_patches=(
 	"1304-xenconsoled-add-support-for-up-to-3-secondary-consol.patch"
 	"1305-xenconsoled-deduplicate-error-handling.patch"
 	"1306-libxl-use-xenconsoled-even-for-multiple-stubdomain-s.patch"
+	"0004-pci-Add-PCI-phantom-functions-to-Xen-based-on-PCI-ve.patch"
 )
 
 
@@ -224,6 +225,7 @@ _feature_patch_sums=(
 	"f0e6381f1204b7741074c5eda0a36a36ea853509d0c7b3824e0bf435e42fcfc299245eb6afb2e57b3408f28fb780e53a83d3033cecfa13a875275985e3480ad0" # 1304-xenconsoled-add-support-for-up-to-3-secondary-consol.patch
 	"aaf5c08a47005d914aa69ab7ca89773d25c125f6d3d89d0626c519feee0d0207bb19f6a19e869d0fc4353a403d9680aa01f5213ac6d27327ba749095b0a77590" # 1305-xenconsoled-deduplicate-error-handling.patch
 	"b3160b15e9afa712086db2479998d18d44fe540f11fb8d0f0e8c7d3a4e19a7aca3a56f8fcfca4c354d4e88fd4becf18a529e48006ad0792a6c23a49a63e14aa1" # 1306-libxl-use-xenconsoled-even-for-multiple-stubdomain-s.patch
+	"dfe48466d6fe0166428902b1346b9aecab279f8282c9e87f367f4cf98b2fc21cd9533d3051f575c9a0c9edd6084f0c8491e2341996bfedcc6a4d3f7eb94e48c2" # 0004-pci-Add-PCI-phantom-functions-to-Xen-based-on-PCI-ve.patch
 )
 
 


### PR DESCRIPTION
These devices require some PCI phantom functions to function properly. These quirks have been taken from Linux.