### PR TITLE
xen: High Precision Event Timer improvements

### DIFF
--- a/xen/0005-x86-hpet-Pre-cleanup.patch
+++ b/xen/0005-x86-hpet-Pre-cleanup.patch
@@ -1,0 +1,134 @@
+From 4c95c1ee8d89e43eab588908d0062de814027250 Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Wed, 13 Nov 2013 14:43:54 +0000
+Subject: [PATCH 1/3] x86/hpet: Pre cleanup
+
+These changes are ones which are able to be pulled out of the subsequent
+patch, to make it clearer to understand and review.
+
+They are all misc fixes with negligible functional changes.
+
+* Rename hpet_next_event -> hpet_set_counter and convert it to take an
+  hpet_event_channel pointer rather than a timer index.
+
+* Rename reprogram_hpet_evt_channel -> hpet_program_time
+
+* Move the position of setting up HPET_EVT_LEGACY in hpet_broadcast_init() It
+  didn't need to be there.
+
+* Avoid leaking ch->cpumask on error path in hpet_fsb_cap_lookup()
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+CC: Keir Fraser <keir@xen.org>
+CC: Jan Beulich <JBeulich@suse.com>
+Reviewed-by: Tim Deegan <tim@xen.org>
+---
+ xen/arch/x86/hpet.c | 33 +++++++++++++++++++++------------
+ 1 file changed, 21 insertions(+), 12 deletions(-)
+
+diff --git a/xen/arch/x86/hpet.c b/xen/arch/x86/hpet.c
+index 317ef63fb5..a15aa31170 100644
+--- a/xen/arch/x86/hpet.c
++++ b/xen/arch/x86/hpet.c
+@@ -121,7 +121,12 @@ static inline unsigned long ns2ticks(unsigned long nsec, int shift,
+     return (unsigned long) tmp;
+ }
+ 
+-static int hpet_next_event(unsigned long delta, int timer)
++/*
++ * Program an HPET channels counter relative to now.  'delta' is specified in
++ * ticks, and should be calculated with ns2ticks().  The channel lock should
++ * be taken and interrupts must be disabled.
++ */
++static int hpet_set_counter(struct hpet_event_channel *ch, unsigned long delta)
+ {
+     uint32_t cnt, cmp;
+     unsigned long flags;
+@@ -129,7 +134,7 @@ static int hpet_next_event(unsigned long delta, int timer)
+     local_irq_save(flags);
+     cnt = hpet_read32(HPET_COUNTER);
+     cmp = cnt + delta;
+-    hpet_write32(cmp, HPET_Tn_CMP(timer));
++    hpet_write32(cmp, HPET_Tn_CMP(ch->idx));
+     cmp = hpet_read32(HPET_COUNTER);
+     local_irq_restore(flags);
+ 
+@@ -137,9 +142,12 @@ static int hpet_next_event(unsigned long delta, int timer)
+     return ((cmp + 2 - cnt) > delta) ? -ETIME : 0;
+ }
+ 
+-static int reprogram_hpet_evt_channel(
+-    struct hpet_event_channel *ch,
+-    s_time_t expire, s_time_t now, int force)
++/*
++ * Set the time at which an HPET channel should fire.  The channel lock should
++ * be held.
++ */
++static int hpet_program_time(struct hpet_event_channel *ch,
++                             s_time_t expire, s_time_t now, int force)
+ {
+     int64_t delta;
+     int ret;
+@@ -170,11 +178,11 @@ static int reprogram_hpet_evt_channel(
+     delta = max_t(int64_t, delta, MIN_DELTA_NS);
+     delta = ns2ticks(delta, ch->shift, ch->mult);
+ 
+-    ret = hpet_next_event(delta, ch->idx);
++    ret = hpet_set_counter(ch, delta);
+     while ( ret && force )
+     {
+         delta += delta;
+-        ret = hpet_next_event(delta, ch->idx);
++        ret = hpet_set_counter(ch, delta);
+     }
+ 
+     return ret;
+@@ -230,7 +238,7 @@ again:
+         spin_lock_irqsave(&ch->lock, flags);
+ 
+         if ( next_event < ch->next_event &&
+-             reprogram_hpet_evt_channel(ch, next_event, now, 0) )
++             hpet_program_time(ch, next_event, now, 0) )
+             goto again;
+ 
+         spin_unlock_irqrestore(&ch->lock, flags);
+@@ -440,6 +448,8 @@ static void __init hpet_fsb_cap_lookup(void)
+ 
+         if ( hpet_assign_irq(ch) == 0 )
+             num_hpets_used++;
++        else
++            free_cpumask_var(ch->cpumask);
+     }
+ 
+     printk(XENLOG_INFO "HPET: %u timers usable for broadcast (%u total)\n",
+@@ -597,6 +607,8 @@ void __init hpet_broadcast_init(void)
+         cfg |= HPET_CFG_LEGACY;
+         n = 1;
+ 
++        hpet_events->flags = HPET_EVT_LEGACY;
++
+         if ( !force_hpet_broadcast )
+             pv_rtc_handler = handle_rtc_once;
+     }
+@@ -629,9 +641,6 @@ void __init hpet_broadcast_init(void)
+         hpet_events[i].msi.msi_attrib.maskbit = 1;
+         hpet_events[i].msi.msi_attrib.pos = MSI_TYPE_HPET;
+     }
+-
+-    if ( !num_hpets_used )
+-        hpet_events->flags = HPET_EVT_LEGACY;
+ }
+ 
+ void hpet_broadcast_resume(void)
+@@ -734,7 +743,7 @@ void cf_check hpet_broadcast_enter(void)
+      * written by a remote cpu, so the value read earlier is still valid.
+      */
+     if ( deadline < ch->next_event )
+-        reprogram_hpet_evt_channel(ch, deadline, NOW(), 1);
++        hpet_program_time(ch, deadline, NOW(), 1);
+     spin_unlock(&ch->lock);
+ }
+ 
+-- 
+2.44.0
+

--- a/xen/0006-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch
+++ b/xen/0006-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch
@@ -1,0 +1,870 @@
+From 1b8cb360a7e85d1381c8a57b52194d8c8d023d2e Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Tue, 4 Mar 2014 10:59:07 +0000
+Subject: [PATCH 2/3] x86/hpet: Use singe apic vector rather than irq_descs for
+ HPET interrupts
+
+This involves rewriting most of the MSI related HPET code, and as a result
+this patch looks very complicated.  It is probably best viewed as an end
+result, with the following notes explaining what is going on.
+
+The new logic is as follows:
+ * A single high priority vector is allocated and uses on all cpus.
+ * Reliance on the irq infrastructure is completely removed.
+ * Tracking of free hpet channels has changed.  It is now an individual
+   bitmap, and allocation is based on winning a test_and_clear_bit()
+   operation.
+ * There is a notion of strict ownership of hpet channels.
+ ** A cpu which owns an HPET channel can program it for a desired deadline.
+ ** A cpu which can't find a free HPET channel will have to share.
+
+ ** If an HPET firing at an appropriate time can be found (up to 20us late), a
+    CPU will simply request to be woken up with that HPET.
+ ** Failing finding an appropriate timed HPET, a CPU shall find the soonest
+    late HPET and program it earlier.
+ ** Failing any late HPETs, a CPU shall wake up with the latest early HPET it
+    can find.
+ ** Failing all else, a CPU shall retry to find a free HPET.  This guarantees
+    that a CPU will never leave hpet_broadcast_enter() without arranging an
+    interrupt.
+ * Some functions have been renamed to be more descriptive.  Some functions
+   have parameters changed to be more consistent.
+
+Contains a folded half bugfix from Frediano:
+Signed-off-by: Frediano Ziglio <frediano.ziglio@citrix.com>
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+CC: Keir Fraser <keir@xen.org>
+CC: Jan Beulich <JBeulich@suse.com>
+CC: Tim Deegan <tim@xen.org>
+---
+ xen/arch/x86/hpet.c | 606 +++++++++++++++++++++-----------------------
+ 1 file changed, 291 insertions(+), 315 deletions(-)
+
+diff --git a/xen/arch/x86/hpet.c b/xen/arch/x86/hpet.c
+index a15aa31170..f35cf1f910 100644
+--- a/xen/arch/x86/hpet.c
++++ b/xen/arch/x86/hpet.c
+@@ -4,27 +4,23 @@
+  * HPET management.
+  */
+ 
++#include <xen/lib.h>
++#include <xen/init.h>
++#include <xen/cpuidle.h>
+ #include <xen/errno.h>
+-#include <xen/time.h>
+-#include <xen/timer.h>
+-#include <xen/smp.h>
+ #include <xen/softirq.h>
+-#include <xen/irq.h>
+-#include <xen/numa.h>
+ #include <xen/param.h>
+ #include <xen/sched.h>
++
++#include <mach_apic.h>
++
+ #include <asm/fixmap.h>
+ #include <asm/div64.h>
+ #include <asm/hpet.h>
+-#include <asm/msi.h>
+-#include <mach_apic.h>
+-#include <xen/cpuidle.h>
+ 
+ #define MAX_DELTA_NS MILLISECS(10*1000)
+ #define MIN_DELTA_NS MICROSECS(20)
+ 
+-#define HPET_EVT_USED_BIT    0
+-#define HPET_EVT_USED       (1 << HPET_EVT_USED_BIT)
+ #define HPET_EVT_DISABLE_BIT 1
+ #define HPET_EVT_DISABLE    (1 << HPET_EVT_DISABLE_BIT)
+ #define HPET_EVT_LEGACY_BIT  2
+@@ -37,8 +33,6 @@ struct hpet_event_channel
+     s_time_t      next_event;
+     cpumask_var_t cpumask;
+     spinlock_t    lock;
+-    void          (*event_handler)(struct hpet_event_channel *);
+-
+     unsigned int idx;   /* physical channel idx */
+     unsigned int cpu;   /* msi target */
+     struct msi_desc msi;/* msi state */
+@@ -49,8 +43,20 @@ static struct hpet_event_channel *__read_mostly hpet_events;
+ /* msi hpet channels used for broadcast */
+ static unsigned int __read_mostly num_hpets_used;
+ 
+-static DEFINE_PER_CPU(struct hpet_event_channel *, cpu_bc_channel);
++/* High-priority vector for HPET interrupts */
++static u8 __read_mostly hpet_vector;
+ 
++/*
++ * HPET channel used for idling.  Either the HPET channel this cpu owns
++ * (indicated by channel->cpu pointing back), or the HPET channel belonging to
++ * another cpu with which we have requested to be woken.
++ */
++static DEFINE_PER_CPU(struct hpet_event_channel *, hpet_channel);
++
++/* Bitmap of currently-free HPET channels. */
++static uint32_t free_channels;
++
++/* Data from the HPET ACPI table */
+ unsigned long __initdata hpet_address;
+ int8_t __initdata opt_hpet_legacy_replacement = -1;
+ static bool __initdata opt_hpet = true;
+@@ -188,83 +194,43 @@ static int hpet_program_time(struct hpet_event_channel *ch,
+     return ret;
+ }
+ 
+-static void evt_do_broadcast(cpumask_t *mask)
++/* Wake up all cpus in the channel mask.  Lock should be held. */
++static void hpet_wake_cpus(struct hpet_event_channel *ch)
+ {
+-    unsigned int cpu = smp_processor_id();
+-
+-    if ( __cpumask_test_and_clear_cpu(cpu, mask) )
+-        raise_softirq(TIMER_SOFTIRQ);
+-
+-    cpuidle_wakeup_mwait(mask);
+-
+-    if ( !cpumask_empty(mask) )
+-       cpumask_raise_softirq(mask, TIMER_SOFTIRQ);
++    cpuidle_wakeup_mwait(ch->cpumask);
++    cpumask_raise_softirq(ch->cpumask, TIMER_SOFTIRQ);
+ }
+ 
+-static void cf_check handle_hpet_broadcast(struct hpet_event_channel *ch)
++/* HPET interrupt handler.  Wake all requested cpus.  Lock should be held. */
++static void hpet_interrupt_handler(struct hpet_event_channel *ch)
+ {
+-    cpumask_t mask;
+-    s_time_t now, next_event;
+-    unsigned int cpu;
+-    unsigned long flags;
+-
+-    spin_lock_irqsave(&ch->lock, flags);
+-
+-again:
+-    ch->next_event = STIME_MAX;
+-
+-    spin_unlock_irqrestore(&ch->lock, flags);
+-
+-    next_event = STIME_MAX;
+-    cpumask_clear(&mask);
+-    now = NOW();
+-
+-    /* find all expired events */
+-    for_each_cpu(cpu, ch->cpumask)
+-    {
+-        s_time_t deadline = ACCESS_ONCE(per_cpu(timer_deadline, cpu));
+-
+-        if ( deadline <= now )
+-            __cpumask_set_cpu(cpu, &mask);
+-        else if ( deadline < next_event )
+-            next_event = deadline;
+-    }
+-
+-    /* wakeup the cpus which have an expired event. */
+-    evt_do_broadcast(&mask);
+-
+-    if ( next_event != STIME_MAX )
+-    {
+-        spin_lock_irqsave(&ch->lock, flags);
+-
+-        if ( next_event < ch->next_event &&
+-             hpet_program_time(ch, next_event, now, 0) )
+-            goto again;
+-
+-        spin_unlock_irqrestore(&ch->lock, flags);
+-    }
++    hpet_wake_cpus(ch);
++    raise_softirq(TIMER_SOFTIRQ);
+ }
+ 
+-static void cf_check hpet_interrupt_handler(
+-    int irq, void *data, struct cpu_user_regs *regs)
++/* HPET interrupt entry.  This is set up as a high priority vector. */
++static void do_hpet_irq(struct cpu_user_regs *regs)
+ {
+-    struct hpet_event_channel *ch = data;
+-
+-    this_cpu(irq_count)--;
++    struct hpet_event_channel *ch = this_cpu(hpet_channel);
+ 
+-    if ( !ch->event_handler )
++    if ( ch )
+     {
+-        printk(XENLOG_WARNING "Spurious HPET timer interrupt on HPET timer %d\n", ch->idx);
+-        return;
++        spin_lock(&ch->lock);
++        if ( ch->cpu == smp_processor_id() )
++        {
++            ch->next_event = 0;
++            hpet_interrupt_handler(ch);
++        }
++        spin_unlock(&ch->lock);
+     }
+ 
+-    ch->event_handler(ch);
++    ack_APIC_irq();
+ }
+ 
+-static void cf_check hpet_msi_unmask(struct irq_desc *desc)
++/* Unmask an HPET MSI channel.  Lock should be held */
++static void hpet_msi_unmask(struct hpet_event_channel *ch)
+ {
+     u32 cfg;
+-    struct hpet_event_channel *ch = desc->action->dev_id;
+ 
+     cfg = hpet_read32(HPET_Tn_CFG(ch->idx));
+     cfg |= HPET_TN_ENABLE;
+@@ -272,10 +238,10 @@ static void cf_check hpet_msi_unmask(struct irq_desc *desc)
+     ch->msi.msi_attrib.host_masked = 0;
+ }
+ 
+-static void cf_check hpet_msi_mask(struct irq_desc *desc)
++/* Mask an HPET MSI channel.  Lock should be held */
++static void hpet_msi_mask(struct hpet_event_channel *ch)
+ {
+     u32 cfg;
+-    struct hpet_event_channel *ch = desc->action->dev_id;
+ 
+     cfg = hpet_read32(HPET_Tn_CFG(ch->idx));
+     cfg &= ~HPET_TN_ENABLE;
+@@ -283,83 +249,36 @@ static void cf_check hpet_msi_mask(struct irq_desc *desc)
+     ch->msi.msi_attrib.host_masked = 1;
+ }
+ 
+-static int hpet_msi_write(struct hpet_event_channel *ch, struct msi_msg *msg)
++/*
++ * Set up the MSI for an HPET channel to point at the allocated cpu, including
++ * interrupt remapping entries when appropriate.  The channel lock is expected
++ * to be held, and the MSI must currently be masked.
++ */
++static int hpet_setup_msi(struct hpet_event_channel *ch)
+ {
+-    ch->msi.msg = *msg;
++    ASSERT(ch->cpu != -1);
++    ASSERT(ch->msi.msi_attrib.host_masked == 1);
++
++    msi_compose_msg(hpet_vector, cpumask_of(ch->cpu), &ch->msi.msg);
+ 
+     if ( iommu_intremap )
+     {
+-        int rc = iommu_update_ire_from_msi(&ch->msi, msg);
++        int rc = iommu_update_ire_from_msi(&ch->msi, &ch->msi.msg);
+ 
+         if ( rc )
+             return rc;
+     }
+ 
+-    hpet_write32(msg->data, HPET_Tn_ROUTE(ch->idx));
+-    hpet_write32(msg->address_lo, HPET_Tn_ROUTE(ch->idx) + 4);
++    hpet_write32(ch->msi.msg.data, HPET_Tn_ROUTE(ch->idx));
++    hpet_write32(ch->msi.msg.address_lo, HPET_Tn_ROUTE(ch->idx) + 4);
+ 
+     return 0;
+ }
+ 
+-static unsigned int cf_check hpet_msi_startup(struct irq_desc *desc)
+-{
+-    hpet_msi_unmask(desc);
+-    return 0;
+-}
+-
+-#define hpet_msi_shutdown hpet_msi_mask
+-
+-static void cf_check hpet_msi_ack(struct irq_desc *desc)
+-{
+-    irq_complete_move(desc);
+-    move_native_irq(desc);
+-    ack_APIC_irq();
+-}
+-
+-static void cf_check hpet_msi_set_affinity(
+-    struct irq_desc *desc, const cpumask_t *mask)
+-{
+-    struct hpet_event_channel *ch = desc->action->dev_id;
+-    struct msi_msg msg = ch->msi.msg;
+-
+-    msg.dest32 = set_desc_affinity(desc, mask);
+-    if ( msg.dest32 == BAD_APICID )
+-        return;
+-
+-    msg.data &= ~MSI_DATA_VECTOR_MASK;
+-    msg.data |= MSI_DATA_VECTOR(desc->arch.vector);
+-    msg.address_lo &= ~MSI_ADDR_DEST_ID_MASK;
+-    msg.address_lo |= MSI_ADDR_DEST_ID(msg.dest32);
+-    if ( msg.data != ch->msi.msg.data || msg.dest32 != ch->msi.msg.dest32 )
+-        hpet_msi_write(ch, &msg);
+-}
+-
+-/*
+- * IRQ Chip for MSI HPET Devices,
+- */
+-static hw_irq_controller hpet_msi_type = {
+-    .typename   = "HPET-MSI",
+-    .startup    = hpet_msi_startup,
+-    .shutdown   = hpet_msi_shutdown,
+-    .enable	    = hpet_msi_unmask,
+-    .disable    = hpet_msi_mask,
+-    .ack        = hpet_msi_ack,
+-    .set_affinity   = hpet_msi_set_affinity,
+-};
+-
+-static int __hpet_setup_msi_irq(struct irq_desc *desc)
+-{
+-    struct msi_msg msg;
+-
+-    msi_compose_msg(desc->arch.vector, desc->arch.cpu_mask, &msg);
+-    return hpet_msi_write(desc->action->dev_id, &msg);
+-}
+-
+-static int __init hpet_setup_msi_irq(struct hpet_event_channel *ch)
++static int __init hpet_init_msi(struct hpet_event_channel *ch)
+ {
+     int ret;
+     u32 cfg = hpet_read32(HPET_Tn_CFG(ch->idx));
+-    irq_desc_t *desc = irq_to_desc(ch->msi.irq);
+ 
+     if ( iommu_intremap )
+     {
+@@ -370,41 +289,31 @@ static int __init hpet_setup_msi_irq(struct hpet_event_channel *ch)
+     }
+ 
+     /* set HPET Tn as oneshot */
+-    cfg &= ~(HPET_TN_LEVEL | HPET_TN_PERIODIC);
++    cfg &= ~(HPET_TN_LEVEL | HPET_TN_PERIODIC | HPET_TN_ENABLE);
+     cfg |= HPET_TN_FSB | HPET_TN_32BIT;
+     hpet_write32(cfg, HPET_Tn_CFG(ch->idx));
+-
+-    desc->handler = &hpet_msi_type;
+-    ret = request_irq(ch->msi.irq, 0, hpet_interrupt_handler, "HPET", ch);
+-    if ( ret >= 0 )
+-        ret = __hpet_setup_msi_irq(desc);
+-    if ( ret < 0 )
+-    {
+-        if ( iommu_intremap )
+-            iommu_update_ire_from_msi(&ch->msi, NULL);
+-        return ret;
+-    }
+-
+-    desc->msi_desc = &ch->msi;
++    ch->msi.msi_attrib.host_masked = 1;
+ 
+     return 0;
+ }
+ 
+-static int __init hpet_assign_irq(struct hpet_event_channel *ch)
++static void __init hpet_init_channel(struct hpet_event_channel *ch)
+ {
+-    int irq;
+-
+-    if ( (irq = create_irq(NUMA_NO_NODE, false)) < 0 )
+-        return irq;
++    u64 hpet_rate = hpet_setup();
+ 
+-    ch->msi.irq = irq;
+-    if ( hpet_setup_msi_irq(ch) )
+-    {
+-        destroy_irq(irq);
+-        return -EINVAL;
+-    }
++    /*
++     * The period is a femto seconds value. We need to calculate the scaled
++     * math multiplication factor for nanosecond to hpet tick conversion.
++     */
++    ch->mult = div_sc((unsigned long)hpet_rate,
++                                     1000000000ul, 32);
++    ch->shift = 32;
++    ch->next_event = STIME_MAX;
++    spin_lock_init(&ch->lock);
+ 
+-    return 0;
++    ch->msi.irq = -1;
++    ch->msi.msi_attrib.maskbit = 1;
++    ch->msi.msi_attrib.pos = MSI_TYPE_HPET;
+ }
+ 
+ static void __init hpet_fsb_cap_lookup(void)
+@@ -424,6 +333,8 @@ static void __init hpet_fsb_cap_lookup(void)
+     if ( !hpet_events )
+         return;
+ 
++    alloc_direct_apic_vector(&hpet_vector, do_hpet_irq);
++
+     for ( i = 0; i < num_chs && num_hpets_used < nr_cpu_ids; i++ )
+     {
+         struct hpet_event_channel *ch = &hpet_events[num_hpets_used];
+@@ -443,10 +354,12 @@ static void __init hpet_fsb_cap_lookup(void)
+             break;
+         }
+ 
++        hpet_init_channel(ch);
++
+         ch->flags = 0;
+         ch->idx = i;
+ 
+-        if ( hpet_assign_irq(ch) == 0 )
++        if ( hpet_init_msi(ch) == 0 )
+             num_hpets_used++;
+         else
+             free_cpumask_var(ch->cpumask);
+@@ -456,104 +369,28 @@ static void __init hpet_fsb_cap_lookup(void)
+            num_hpets_used, num_chs);
+ }
+ 
+-static struct hpet_event_channel *hpet_get_channel(unsigned int cpu)
++/*
++ * Search for, and allocate, a free HPET channel.  Returns a pointer to the
++ * channel, or NULL in the case that none were free.  The caller is
++ * responsible for returning the channel to the free pool.
++ */
++static struct hpet_event_channel *hpet_get_free_channel(void)
+ {
+-    static unsigned int next_channel;
+-    unsigned int i, next;
+-    struct hpet_event_channel *ch;
++    unsigned ch, tries;
+ 
+-    if ( num_hpets_used == 0 )
+-        return hpet_events;
+-
+-    if ( num_hpets_used >= nr_cpu_ids )
+-        return &hpet_events[cpu];
+-
+-    do {
+-        next = next_channel;
+-        if ( (i = next + 1) == num_hpets_used )
+-            i = 0;
+-    } while ( cmpxchg(&next_channel, next, i) != next );
+-
+-    /* try unused channel first */
+-    for ( i = next; i < next + num_hpets_used; i++ )
++    for ( tries = num_hpets_used; tries; --tries )
+     {
+-        ch = &hpet_events[i % num_hpets_used];
+-        if ( !test_and_set_bit(HPET_EVT_USED_BIT, &ch->flags) )
+-        {
+-            ch->cpu = cpu;
+-            return ch;
+-        }
+-    }
+-
+-    /* share a in-use channel */
+-    ch = &hpet_events[next];
+-    if ( !test_and_set_bit(HPET_EVT_USED_BIT, &ch->flags) )
+-        ch->cpu = cpu;
+-
+-    return ch;
+-}
+-
+-static void set_channel_irq_affinity(struct hpet_event_channel *ch)
+-{
+-    struct irq_desc *desc = irq_to_desc(ch->msi.irq);
+-
+-    ASSERT(!local_irq_is_enabled());
+-    spin_lock(&desc->lock);
+-    hpet_msi_mask(desc);
+-    hpet_msi_set_affinity(desc, cpumask_of(ch->cpu));
+-    hpet_msi_unmask(desc);
+-    spin_unlock(&desc->lock);
+-
+-    spin_unlock(&ch->lock);
+-
+-    /* We may have missed an interrupt due to the temporary masking. */
+-    if ( ch->event_handler && ch->next_event < NOW() )
+-        ch->event_handler(ch);
+-}
+-
+-static void hpet_attach_channel(unsigned int cpu,
+-                                struct hpet_event_channel *ch)
+-{
+-    ASSERT(!local_irq_is_enabled());
+-    spin_lock(&ch->lock);
+-
+-    per_cpu(cpu_bc_channel, cpu) = ch;
+-
+-    /* try to be the channel owner again while holding the lock */
+-    if ( !test_and_set_bit(HPET_EVT_USED_BIT, &ch->flags) )
+-        ch->cpu = cpu;
+-
+-    if ( ch->cpu != cpu )
+-        spin_unlock(&ch->lock);
+-    else
+-        set_channel_irq_affinity(ch);
+-}
+-
+-static void hpet_detach_channel(unsigned int cpu,
+-                                struct hpet_event_channel *ch)
+-{
+-    unsigned int next;
+-
+-    spin_lock_irq(&ch->lock);
+-
+-    ASSERT(ch == per_cpu(cpu_bc_channel, cpu));
++        if ( (ch = ffs(free_channels)) == 0 )
++            break;
+ 
+-    per_cpu(cpu_bc_channel, cpu) = NULL;
++        --ch;
++        ASSERT(ch < num_hpets_used);
+ 
+-    if ( cpu != ch->cpu )
+-        spin_unlock_irq(&ch->lock);
+-    else if ( (next = cpumask_first(ch->cpumask)) >= nr_cpu_ids )
+-    {
+-        ch->cpu = -1;
+-        clear_bit(HPET_EVT_USED_BIT, &ch->flags);
+-        spin_unlock_irq(&ch->lock);
+-    }
+-    else
+-    {
+-        ch->cpu = next;
+-        set_channel_irq_affinity(ch);
+-        local_irq_enable();
++        if ( test_and_clear_bit(ch, &free_channels) )
++            return &hpet_events[ch];
+     }
++
++    return NULL;
+ }
+ 
+ #include <asm/mc146818rtc.h>
+@@ -577,7 +414,6 @@ void __init hpet_broadcast_init(void)
+ {
+     u64 hpet_rate = hpet_setup();
+     u32 hpet_id, cfg;
+-    unsigned int i, n;
+ 
+     if ( hpet_rate == 0 || hpet_broadcast_is_available() )
+         return;
+@@ -589,7 +425,7 @@ void __init hpet_broadcast_init(void)
+     {
+         /* Stop HPET legacy interrupts */
+         cfg &= ~HPET_CFG_LEGACY;
+-        n = num_hpets_used;
++        free_channels = (u32)~0 >> (32 - num_hpets_used);
+     }
+     else
+     {
+@@ -601,11 +437,11 @@ void __init hpet_broadcast_init(void)
+             hpet_events = xzalloc(struct hpet_event_channel);
+         if ( !hpet_events || !zalloc_cpumask_var(&hpet_events->cpumask) )
+             return;
+-        hpet_events->msi.irq = -1;
++
++        hpet_init_channel(hpet_events);
+ 
+         /* Start HPET legacy interrupts */
+         cfg |= HPET_CFG_LEGACY;
+-        n = 1;
+ 
+         hpet_events->flags = HPET_EVT_LEGACY;
+ 
+@@ -615,31 +451,13 @@ void __init hpet_broadcast_init(void)
+ 
+     hpet_write32(cfg, HPET_CFG);
+ 
+-    for ( i = 0; i < n; i++ )
++    if ( cfg & HPET_CFG_LEGACY )
+     {
+-        if ( i == 0 && (cfg & HPET_CFG_LEGACY) )
+-        {
+-            /* set HPET T0 as oneshot */
+-            cfg = hpet_read32(HPET_Tn_CFG(0));
+-            cfg &= ~(HPET_TN_LEVEL | HPET_TN_PERIODIC);
+-            cfg |= HPET_TN_ENABLE | HPET_TN_32BIT;
+-            hpet_write32(cfg, HPET_Tn_CFG(0));
+-        }
+-
+-        /*
+-         * The period is a femto seconds value. We need to calculate the scaled
+-         * math multiplication factor for nanosecond to hpet tick conversion.
+-         */
+-        hpet_events[i].mult = div_sc((unsigned long)hpet_rate,
+-                                     1000000000UL, 32);
+-        hpet_events[i].shift = 32;
+-        hpet_events[i].next_event = STIME_MAX;
+-        spin_lock_init(&hpet_events[i].lock);
+-        smp_wmb();
+-        hpet_events[i].event_handler = handle_hpet_broadcast;
+-
+-        hpet_events[i].msi.msi_attrib.maskbit = 1;
+-        hpet_events[i].msi.msi_attrib.pos = MSI_TYPE_HPET;
++        /* set HPET T0 as oneshot */
++        cfg = hpet_read32(HPET_Tn_CFG(0));
++        cfg &= ~(HPET_TN_LEVEL | HPET_TN_PERIODIC);
++        cfg |= HPET_TN_ENABLE | HPET_TN_32BIT;
++        hpet_write32(cfg, HPET_Tn_CFG(0));
+     }
+ }
+ 
+@@ -674,15 +492,24 @@ void hpet_broadcast_resume(void)
+ 
+     for ( i = 0; i < n; i++ )
+     {
+-        if ( hpet_events[i].msi.irq >= 0 )
+-            __hpet_setup_msi_irq(irq_to_desc(hpet_events[i].msi.irq));
+-
+         /* set HPET Tn as oneshot */
+         cfg = hpet_read32(HPET_Tn_CFG(hpet_events[i].idx));
+         cfg &= ~(HPET_TN_LEVEL | HPET_TN_PERIODIC);
+-        cfg |= HPET_TN_ENABLE | HPET_TN_32BIT;
+-        if ( !(hpet_events[i].flags & HPET_EVT_LEGACY) )
++        cfg |= HPET_TN_32BIT;
++
++        /*
++         * Legacy HPET channel enabled here.  MSI channels enabled in
++         * hpet_broadcast_init() when claimed by a cpu.
++         */
++        if ( hpet_events[i].flags & HPET_EVT_LEGACY )
++            cfg |= HPET_TN_ENABLE;
++        else
++        {
++            cfg &= ~HPET_TN_ENABLE;
+             cfg |= HPET_TN_FSB;
++            hpet_events[i].msi.msi_attrib.host_masked = 1;
++        }
++
+         hpet_write32(cfg, HPET_Tn_CFG(hpet_events[i].idx));
+ 
+         hpet_events[i].next_event = STIME_MAX;
+@@ -719,55 +546,197 @@ void hpet_disable_legacy_broadcast(void)
+ void cf_check hpet_broadcast_enter(void)
+ {
+     unsigned int cpu = smp_processor_id();
+-    struct hpet_event_channel *ch = per_cpu(cpu_bc_channel, cpu);
++    struct hpet_event_channel *ch = per_cpu(hpet_channel, cpu);
+     s_time_t deadline = per_cpu(timer_deadline, cpu);
+ 
++    ASSERT(!local_irq_is_enabled());
++    ASSERT(ch == NULL);
++
+     if ( deadline == 0 )
+         return;
+ 
+-    if ( !ch )
+-        ch = hpet_get_channel(cpu);
++    /* If using HPET in legacy timer mode */
++    if ( num_hpets_used == 0 )
++    {
++        spin_lock(&hpet_events->lock);
+ 
+-    ASSERT(!local_irq_is_enabled());
++        cpumask_set_cpu(cpu, hpet_events->cpumask);
++        if ( deadline < hpet_events->next_event )
++            hpet_program_time(hpet_events, deadline, NOW(), 1);
++
++        spin_unlock(&hpet_events->lock);
++        return;
++    }
+ 
+-    if ( !(ch->flags & HPET_EVT_LEGACY) )
+-        hpet_attach_channel(cpu, ch);
++retry_free_channel:
++    ch = hpet_get_free_channel();
+ 
+-    /* Disable LAPIC timer interrupts. */
+-    disable_APIC_timer();
+-    cpumask_set_cpu(cpu, ch->cpumask);
++    if ( ch )
++    {
++        spin_lock(&ch->lock);
+ 
+-    spin_lock(&ch->lock);
+-    /*
+-     * Reprogram if current cpu expire time is nearer.  deadline is never
+-     * written by a remote cpu, so the value read earlier is still valid.
+-     */
+-    if ( deadline < ch->next_event )
++        /* This really should be an MSI channel by this point */
++        ASSERT(!(ch->flags & HPET_EVT_LEGACY));
++
++        hpet_msi_mask(ch);
++
++        ch->cpu = cpu;
++        this_cpu(hpet_channel) = ch;
++        cpumask_set_cpu(cpu, ch->cpumask);
++
++        hpet_setup_msi(ch);
+         hpet_program_time(ch, deadline, NOW(), 1);
+-    spin_unlock(&ch->lock);
+-}
++        hpet_msi_unmask(ch);
++
++        spin_unlock(&ch->lock);
++    }
++    else
++    {
++        s_time_t best_early_deadline = 0, best_late_deadline = STIME_MAX;
++        unsigned int i, best_early_idx = -1, best_late_idx = -1;
++
++        for ( i = 0; i < num_hpets_used; ++i )
++        {
++            ch = &hpet_events[i];
++            spin_lock(&ch->lock);
++
++            if ( ch->cpu == -1 )
++                goto continue_search;
++
++            /* This channel is going to expire early */
++            if ( ch->next_event < deadline )
++            {
++                if ( ch->next_event > best_early_deadline )
++                {
++                    best_early_idx = i;
++                    best_early_deadline = ch->next_event;
++                }
++                goto continue_search;
++            }
++
++            /* We can deal with being woken up 20us late */
++            if ( ch->next_event <= deadline + MICROSECS(20) )
++                break;
++
++            /* Otherwise record the best late channel to program forwards */
++            if ( ch->next_event <= best_late_deadline )
++            {
++                best_late_idx = i;
++                best_late_deadline = ch->next_event;
++            }
++
++        continue_search:
++            spin_unlock(&ch->lock);
++            ch = NULL;
++        }
++
++        if ( ch )
++        {
++            /* Found HPET with an appropriate time.  Request to be woken up */
++            cpumask_set_cpu(cpu, ch->cpumask);
++            this_cpu(hpet_channel) = ch;
++            spin_unlock(&ch->lock);
++            goto done_searching;
++        }
++
++        /* Try and program the best late channel forwards a bit */
++        if ( best_late_deadline < STIME_MAX && best_late_idx != -1 )
++        {
++            ch = &hpet_events[best_late_idx];
++            spin_lock(&ch->lock);
++
++            /* If this is still the same channel, good */
++            if ( ch->next_event == best_late_deadline )
++            {
++                cpumask_set_cpu(cpu, ch->cpumask);
++                hpet_program_time(ch, deadline, NOW(), 1);
++                spin_unlock(&ch->lock);
++                goto done_searching;
++            }
++            /* else it has fired and changed ownership. */
++            else
++            {
++                spin_unlock(&ch->lock);
++                goto retry_free_channel;
++            }
++        }
++
++        /* Try to piggyback on an early channel in the hope that when we
++           wake back up, our fortunes will improve. */
++        if ( best_early_deadline > 0 && best_early_idx != -1 )
++        {
++            ch = &hpet_events[best_early_idx];
++            spin_lock(&ch->lock);
++
++            /* If this is still the same channel, good */
++            if ( ch->next_event == best_early_deadline )
++            {
++                cpumask_set_cpu(cpu, ch->cpumask);
++                spin_unlock(&ch->lock);
++                goto done_searching;
++            }
++            /* else it has fired and changed ownership. */
++            else
++            {
++                spin_unlock(&ch->lock);
++                goto retry_free_channel;
++            }
++        }
++
++        /* All else has failed, and we have wasted some time searching.
++         * See whether another channel has become free. */
++        goto retry_free_channel;
++    }
++
++done_searching:
++
++    /* Disable LAPIC timer interrupts. */
++    disable_APIC_timer();
++ }
+ 
+ void cf_check hpet_broadcast_exit(void)
+ {
+     unsigned int cpu = smp_processor_id();
+-    struct hpet_event_channel *ch = per_cpu(cpu_bc_channel, cpu);
++    struct hpet_event_channel *ch = this_cpu(hpet_channel);
+     s_time_t deadline = per_cpu(timer_deadline, cpu);
+ 
++    ASSERT(local_irq_is_enabled());
++
+     if ( deadline == 0 )
+         return;
+ 
++    /* If using HPET in legacy timer mode */
++    if ( num_hpets_used == 0 )
++    {
++        /* This is safe without the spinlock, and will reduce contention. */
++        cpumask_clear_cpu(cpu, hpet_events->cpumask);
++        return;
++    }
++
+     if ( !ch )
+-        ch = hpet_get_channel(cpu);
++        return;
++
++    spin_lock_irq(&ch->lock);
++
++    cpumask_clear_cpu(cpu, ch->cpumask);
++
++    /* If we own the channel, detach it */
++    if ( ch->cpu == cpu )
++    {
++        hpet_msi_mask(ch);
++        hpet_wake_cpus(ch);
++        ch->cpu = -1;
++        set_bit(ch->idx, &free_channels);
++    }
++
++    this_cpu(hpet_channel) = NULL;
++
++    spin_unlock_irq(&ch->lock);
+ 
+     /* Reprogram the deadline; trigger timer work now if it has passed. */
+     enable_APIC_timer();
+     if ( !reprogram_timer(deadline) )
+         raise_softirq(TIMER_SOFTIRQ);
+-
+-    cpumask_clear_cpu(cpu, ch->cpumask);
+-
+-    if ( !(ch->flags & HPET_EVT_LEGACY) )
+-        hpet_detach_channel(cpu, ch);
+ }
+ 
+ int hpet_broadcast_is_available(void)
+@@ -784,7 +753,14 @@ int hpet_legacy_irq_tick(void)
+          (hpet_events->flags & (HPET_EVT_DISABLE|HPET_EVT_LEGACY)) !=
+          HPET_EVT_LEGACY )
+         return 0;
+-    hpet_events->event_handler(hpet_events);
++
++    spin_lock_irq(&hpet_events->lock);
++
++    hpet_interrupt_handler(hpet_events);
++    hpet_events->next_event = STIME_MAX;
++
++    spin_unlock_irq(&hpet_events->lock);
++
+     return 1;
+ }
+ 
+-- 
+2.44.0
+

--- a/xen/0007-x86-hpet-Post-cleanup.patch
+++ b/xen/0007-x86-hpet-Post-cleanup.patch
@@ -1,0 +1,87 @@
+From 2dc0f184fe829ed8a0a9d5103dd906fa73da5a5f Mon Sep 17 00:00:00 2001
+From: Andrew Cooper <andrew.cooper3@citrix.com>
+Date: Wed, 13 Nov 2013 17:07:10 +0000
+Subject: [PATCH 3/3] x86/hpet: Post cleanup
+
+These changes are ones which were able to be pulled out of the previous patch.
+They are all misc cleanup without functional implications
+
+* Shift HPET_EVT_* definitions up now that USED has moved out
+
+* Shuffle struct hpet_event_channel
+** Reflow horizontally and comment current use
+** Promote 'shift' to unsigned.  It is the constant 32 but can be more easily
+   optimised.
+** Move 'flags' up to fill 4 byte hole
+** Move 'cpumask' and 'lock' into second cache line as they are diried from
+   other cpus
+
+* The new locking requirements guarentee that interrupts are disabled in
+  hpet_set_counter.  Leave an ASSERT() just in case.
+
+Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>
+CC: Keir Fraser <keir@xen.org>
+CC: Jan Beulich <JBeulich@suse.com>
+Reviewed-by: Tim Deegan <tim@xen.org>
+---
+ xen/arch/x86/hpet.c | 27 +++++++++++++--------------
+ 1 file changed, 13 insertions(+), 14 deletions(-)
+
+diff --git a/xen/arch/x86/hpet.c b/xen/arch/x86/hpet.c
+index f35cf1f910..46ef5a5ca6 100644
+--- a/xen/arch/x86/hpet.c
++++ b/xen/arch/x86/hpet.c
+@@ -21,22 +21,22 @@
+ #define MAX_DELTA_NS MILLISECS(10*1000)
+ #define MIN_DELTA_NS MICROSECS(20)
+ 
+-#define HPET_EVT_DISABLE_BIT 1
++#define HPET_EVT_DISABLE_BIT 0
+ #define HPET_EVT_DISABLE    (1 << HPET_EVT_DISABLE_BIT)
+-#define HPET_EVT_LEGACY_BIT  2
++#define HPET_EVT_LEGACY_BIT  1
+ #define HPET_EVT_LEGACY     (1 << HPET_EVT_LEGACY_BIT)
+ 
+ struct hpet_event_channel
+ {
+-    unsigned long mult;
+-    int           shift;
+-    s_time_t      next_event;
+-    cpumask_var_t cpumask;
+-    spinlock_t    lock;
+-    unsigned int idx;   /* physical channel idx */
+-    unsigned int cpu;   /* msi target */
+-    struct msi_desc msi;/* msi state */
+-    unsigned int flags; /* HPET_EVT_x */
++    unsigned long   mult;       /* tick <-> time conversion */
++    unsigned int    shift;      /* tick <-> time conversion */
++    unsigned int    flags;      /* HPET_EVT_x */
++    s_time_t        next_event; /* expected time of next interrupt */
++    unsigned int    idx;        /* HPET counter index */
++    unsigned int    cpu;        /* owner of channel (or -1) */
++    struct msi_desc msi;        /* msi state */
++    cpumask_var_t   cpumask;    /* cpus wishing to be woken */
++    spinlock_t      lock;
+ } __cacheline_aligned;
+ static struct hpet_event_channel *__read_mostly hpet_events;
+ 
+@@ -135,14 +135,13 @@ static inline unsigned long ns2ticks(unsigned long nsec, int shift,
+ static int hpet_set_counter(struct hpet_event_channel *ch, unsigned long delta)
+ {
+     uint32_t cnt, cmp;
+-    unsigned long flags;
+ 
+-    local_irq_save(flags);
++    ASSERT(!local_irq_is_enabled());
++
+     cnt = hpet_read32(HPET_COUNTER);
+     cmp = cnt + delta;
+     hpet_write32(cmp, HPET_Tn_CMP(ch->idx));
+     cmp = hpet_read32(HPET_COUNTER);
+-    local_irq_restore(flags);
+ 
+     /* Are we within two ticks of the deadline passing? Then we may miss. */
+     return ((cmp + 2 - cnt) > delta) ? -ETIME : 0;
+-- 
+2.44.0
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -154,6 +154,9 @@ _feature_patches=(
 	"0002-intel-Workaround-Nehalem-and-Westmere-C-states-bugs.patch"
 	"0003-vtd-quirks-Ignore-HP-Gen8-GPU-audio-devices-for-RMRR.patch"
 	"0004-pci-Add-PCI-phantom-functions-to-Xen-based-on-PCI-ve.patch"
+	"0005-x86-hpet-Pre-cleanup.patch"
+	"0006-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch"
+	"0007-x86-hpet-Post-cleanup.patch"
 )
 
 
@@ -240,6 +243,9 @@ _feature_patch_sums=(
 	"0384b29938499d6c281c269ac1adc016a529cacea926dd81b8feb0db00abe80495eb7be86c9f200f2141a0f6a9f25bf7dc440d7e7789db8fd4357a89caaed83b" # 0002-intel-Workaround-Nehalem-and-Westmere-C-states-bugs.patch
 	"1b3b9bcef20fa3257020656cf3268fe216e7b02ec10d39170b2cf0a5b360ad3f23bad99abb769535fb0bdde86528fc2d7b9e109c93f8fe9fc9bdfc710cc4edb8" # 0003-vtd-quirks-Ignore-HP-Gen8-GPU-audio-devices-for-RMRR.patch
 	"dfe48466d6fe0166428902b1346b9aecab279f8282c9e87f367f4cf98b2fc21cd9533d3051f575c9a0c9edd6084f0c8491e2341996bfedcc6a4d3f7eb94e48c2" # 0004-pci-Add-PCI-phantom-functions-to-Xen-based-on-PCI-ve.patch
+	"129fa7ec5930e98a99c15f1efdc0c23ea508492d95095bf1ed84e2a98b131fc0e8523acafe15e44c257ca6d1217a291e30057533daeb78826c368336d2fd0e61" # 0005-x86-hpet-Pre-cleanup.patch
+	"51e95193d3d2a27c9ad7e5fc24a73d88688b7183fee3c037b9f3e8e10ac97427ba869c5c1a5fc6004e5d3d41da66cc63a0c06fe3fd10d6ae4604a744a5d3d776" # 0006-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch
+	"1d016e8f8c0e6a76453e21fefb87949a12be24a48c84d1fdac67aea500e7a6b3721399fd8911f73ddfdfffad8831598a4afc8e207fde8a34a3b52e97c4e23478" # 0007-x86-hpet-Post-cleanup.patch
 )
 
 


### PR DESCRIPTION
This is a fairly complicated set of patches and I can't summarize this
properly, so I'm simply going to link to Andrew's proposal to improve
the HPET subsystem:
https://lore.kernel.org/xen-devel/526A6267.1080004@citrix.com/

The TL;DR is basically that this patchset fixes a set of bugs in the
HPET subsystem, and should improve their handling.

I spoke with Andrew a bit about the patch about a week ago. He mentioned
that the current HPET subsystem is completely broken on Nehalem-era
hardware. The new interrupt handler is not without issues, as it can
result in a stack overflow. Hardware older than Nehalem-era hardware is
especially susceptible to this, as they only have 3 MSI channels on the
HPET, meaning you only need 4~5 interrupts at the same time to overflow
it. Nehalem-era hardware has 8 MSI channels on the HPET and I assume
newer hardware will have even more. As pre-Nehalem CPUs are from
2007-2008, I don't think anybody will be using them for Xen anyway.

So I don't think this will be a big deal for us, as the upsides outweigh
the downsides.