### PR TITLE
xen: Retry shadow ops if -EBUSY is returned

### DIFF
--- a/xen/0008-libxc-retry-shadow-ops-if-EBUSY-is-returned.patch
+++ b/xen/0008-libxc-retry-shadow-ops-if-EBUSY-is-returned.patch
@@ -1,0 +1,47 @@
+From e3dca1f9da207b89b3263c6b71cf94f706f2ed6d Mon Sep 17 00:00:00 2001
+From: David Vrabel <david.vrabel@citrix.com>
+Date: Thu, 22 Jan 2015 10:58:41 +0000
+Subject: [PATCH 08/18] libxc: retry shadow ops if -EBUSY is returned
+
+DOMCTL_shadow_op may return -EBUSY if there is a pending preempted
+hypercall (issued by another task).  Handle this by retrying the op.
+
+Signed-off-by: David Vrabel <david.vrabel@citrix.com>
+---
+ tools/libs/ctrl/xc_domain.c | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/tools/libs/ctrl/xc_domain.c b/tools/libs/ctrl/xc_domain.c
+index 724fa6f753..1da7987972 100644
+--- a/tools/libs/ctrl/xc_domain.c
++++ b/tools/libs/ctrl/xc_domain.c
+@@ -607,6 +607,7 @@ int xc_shadow_control(xc_interface *xch,
+ {
+     int rc;
+     DECLARE_DOMCTL;
++    int retries = 10; /* Retry for approx 100 ms. */
+ 
+     memset(&domctl, 0, sizeof(domctl));
+ 
+@@ -616,7 +617,17 @@ int xc_shadow_control(xc_interface *xch,
+     domctl.u.shadow_op.mb     = mb ? *mb : 0;
+     domctl.u.shadow_op.mode   = mode;
+ 
+-    rc = do_domctl(xch, &domctl);
++    for (;;) {
++        rc = do_domctl(xch, &domctl);
++        if ( rc >= 0 || errno != EBUSY )
++            break;
++
++        if ( --retries == 0 ) {
++            PERROR("Shadow op %u still busy", sop);
++            return rc;
++        }
++        usleep(10000);
++    }
+ 
+     if ( mb )
+         *mb = domctl.u.shadow_op.mb;
+-- 
+2.43.0
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -154,6 +154,7 @@ _feature_patches=(
 	"0005-x86-hpet-Pre-cleanup.patch"
 	"0006-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch"
 	"0007-x86-hpet-Post-cleanup.patch"
+	"0008-libxc-retry-shadow-ops-if-EBUSY-is-returned.patch"
 )
 
 
@@ -242,6 +243,7 @@ _feature_patch_sums=(
 	"129fa7ec5930e98a99c15f1efdc0c23ea508492d95095bf1ed84e2a98b131fc0e8523acafe15e44c257ca6d1217a291e30057533daeb78826c368336d2fd0e61" # 0005-x86-hpet-Pre-cleanup.patch
 	"51e95193d3d2a27c9ad7e5fc24a73d88688b7183fee3c037b9f3e8e10ac97427ba869c5c1a5fc6004e5d3d41da66cc63a0c06fe3fd10d6ae4604a744a5d3d776" # 0006-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch
 	"1d016e8f8c0e6a76453e21fefb87949a12be24a48c84d1fdac67aea500e7a6b3721399fd8911f73ddfdfffad8831598a4afc8e207fde8a34a3b52e97c4e23478" # 0007-x86-hpet-Post-cleanup.patch
+	"ae1a7c9357e77b871040755e55d5ec016c17bf917f7c637a27a944273f58b3ce577934c7c1532874c9515c8456cac4d983f8cb8363524b6b11fbf511593bc780" # 0008-libxc-retry-shadow-ops-if-EBUSY-is-returned.patch
 )
 
 


### PR DESCRIPTION
Attempt to retry certain xencontrol operations (not sure what shadow ops are supposed to be) for around 100ms before passing on the error to the tool.