### PR TITLE
xen: Work around page fault during EFI runtime service

### DIFF
--- a/xen/0010-efi-Workaround-page-fault-during-runtime-service.patch
+++ b/xen/0010-efi-Workaround-page-fault-during-runtime-service.patch
@@ -1,0 +1,49 @@
+From fa255982ed03c774b6d71fd8c4d18726f44a261f Mon Sep 17 00:00:00 2001
+From: Ross Lagerwall <ross.lagerwall@citrix.com>
+Date: Tue, 26 Apr 2016 13:59:38 +0100
+Subject: [PATCH 10/18] efi: Workaround page fault during runtime service
+
+Some hardware makes use of memory of type EfiACPIMemoryNVS during the
+ResetSystem runtime service but does not mark the memory as needing a
+runtime mapping causing a fatal page fault.
+
+To workaround this, map this type of memory for runtime services
+regardless of whether it marked with EFI_MEMORY_RUNTIME.
+
+The hardware on which this behavior was observed:
+Dell OptiPlex 9020
+Firmware version: A15
+Firmware release date: 11/08/2015
+
+Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>
+---
+ xen/common/efi/boot.c | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/xen/common/efi/boot.c b/xen/common/efi/boot.c
+index 1843b65c8f..aacdfac6ea 100644
+--- a/xen/common/efi/boot.c
++++ b/xen/common/efi/boot.c
+@@ -158,6 +158,7 @@ static SIMPLE_TEXT_OUTPUT_INTERFACE *__initdata StdErr;
+ static UINT32 __initdata mdesc_ver;
+ static bool __initdata map_bs;
+ static bool __initdata map_res = true;
++static bool __initdata map_nvs = true;
+ 
+ static struct file __initdata cfg;
+ static struct file __initdata kernel;
+@@ -1753,6 +1754,11 @@ void __init efi_init_memory(void)
+                 desc->Attribute |= EFI_MEMORY_RUNTIME;
+                 break;
+ 
++            case EfiACPIMemoryNVS:
++                if ( !map_nvs )
++                    continue;
++                break;
++
+             case EfiBootServicesCode:
+             case EfiBootServicesData:
+                 if ( !map_bs )
+-- 
+2.43.0
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -154,6 +154,7 @@ _feature_patches=(
 	"0005-x86-hpet-Pre-cleanup.patch"
 	"0006-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch"
 	"0007-x86-hpet-Post-cleanup.patch"
+	"0010-efi-Workaround-page-fault-during-runtime-service.patch"
 )
 
 
@@ -242,6 +243,7 @@ _feature_patch_sums=(
 	"129fa7ec5930e98a99c15f1efdc0c23ea508492d95095bf1ed84e2a98b131fc0e8523acafe15e44c257ca6d1217a291e30057533daeb78826c368336d2fd0e61" # 0005-x86-hpet-Pre-cleanup.patch
 	"51e95193d3d2a27c9ad7e5fc24a73d88688b7183fee3c037b9f3e8e10ac97427ba869c5c1a5fc6004e5d3d41da66cc63a0c06fe3fd10d6ae4604a744a5d3d776" # 0006-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch
 	"1d016e8f8c0e6a76453e21fefb87949a12be24a48c84d1fdac67aea500e7a6b3721399fd8911f73ddfdfffad8831598a4afc8e207fde8a34a3b52e97c4e23478" # 0007-x86-hpet-Post-cleanup.patch
+	"b1ad0fe54dbb7de49348059a81f3c247b66ed29afbd547d4a73f5fc2714a0fd42c6eb64f7c4740ecd7ac81dd44bbd5f6d59465d7b6f366f1527bcf7673defbb8" # 0010-efi-Workaround-page-fault-during-runtime-service.patch
 )
 
 


### PR DESCRIPTION
Some hardware incorrectly does not mark EfiACPIMemoryNVS as needing a runtime mapping. This causes a fatal page fault on those systems. Map the memory regardless of this mark to work around this issue.

This behavior is observed on the Dell Optiplex 9020 with firmware A15.