### PR TITLE
xen: Optimize HVM load/restore time

### DIFF
--- a/xen/0011-x86-HVM-Avoid-cache-flush-operations-during-hvm_load.patch
+++ b/xen/0011-x86-HVM-Avoid-cache-flush-operations-during-hvm_load.patch
@@ -1,0 +1,129 @@
+From 5263665e0e1b831c22ab007855bba0c5a302d511 Mon Sep 17 00:00:00 2001
+From: Ross Lagerwall <ross.lagerwall@citrix.com>
+Date: Wed, 13 May 2015 12:44:29 +0100
+Subject: [PATCH 11/18] x86/HVM: Avoid cache flush operations during hvm_load
+
+An MTRR record is processed for each vCPU during hvm_load. Each MTRR
+record sets several mtrrs, each of which flushes the cache on all pCPUs.
+This can take some time and trip the watchdog for HVM guests with many
+CPUs.
+
+To fix this, introduce a flag which prevents flushing the cache when
+doing MTRR operations and instead do a flush at the end of hvm_load.
+
+This reduces the time to restore an HVM guest with 32 vCPUs by about 5
+seconds.
+
+Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>
+---
+ xen/arch/x86/hvm/mtrr.c         |  5 +++++
+ xen/arch/x86/hvm/save.c         | 18 ++++++++++++++----
+ xen/arch/x86/include/asm/mtrr.h |  9 +++++++++
+ 3 files changed, 28 insertions(+), 4 deletions(-)
+
+diff --git a/xen/arch/x86/hvm/mtrr.c b/xen/arch/x86/hvm/mtrr.c
+index 7f486358b1..629b3c34d5 100644
+--- a/xen/arch/x86/hvm/mtrr.c
++++ b/xen/arch/x86/hvm/mtrr.c
+@@ -44,6 +44,8 @@ static const uint8_t mm_type_tbl[MTRR_NUM_TYPES][X86_NUM_MT] = {
+ #undef RS
+ };
+ 
++DEFINE_PER_CPU(bool, memory_type_changed_ignore);
++
+ /*
+  * Reverse lookup table, to find a pat type according to MTRR and effective
+  * memory type. This table is dynamically generated.
+@@ -778,6 +780,9 @@ HVM_REGISTER_SAVE_RESTORE(MTRR, hvm_save_mtrr_msr, hvm_load_mtrr_msr, 1,
+ 
+ void memory_type_changed(struct domain *d)
+ {
++    if ( this_cpu(memory_type_changed_ignore) )
++        return;
++
+     if ( (is_iommu_enabled(d) || cache_flush_permitted(d)) &&
+          d->vcpu && d->vcpu[0] )
+     {
+diff --git a/xen/arch/x86/hvm/save.c b/xen/arch/x86/hvm/save.c
+index 79713cd6ca..4212eb1001 100644
+--- a/xen/arch/x86/hvm/save.c
++++ b/xen/arch/x86/hvm/save.c
+@@ -299,6 +299,8 @@ int hvm_load(struct domain *d, hvm_domain_context_t *h)
+         if ( !test_and_set_bit(_VPF_down, &v->pause_flags) )
+             vcpu_sleep_nosync(v);
+ 
++    this_cpu(memory_type_changed_ignore) = true;
++
+     for ( ; ; )
+     {
+         if ( h->size - h->cur < sizeof(struct hvm_save_descriptor) )
+@@ -307,13 +309,14 @@ int hvm_load(struct domain *d, hvm_domain_context_t *h)
+             printk(XENLOG_G_ERR
+                    "HVM%d restore: save did not end with a null entry\n",
+                    d->domain_id);
+-            return -ENODATA;
++            rc = -ENODATA;
++            goto out;
+         }
+ 
+         /* Read the typecode of the next entry  and check for the end-marker */
+         desc = (struct hvm_save_descriptor *)(&h->data[h->cur]);
+         if ( desc->typecode == 0 )
+-            return 0;
++            goto out;
+ 
+         /* Find the handler for this entry */
+         if ( (desc->typecode > HVM_SAVE_CODE_MAX) ||
+@@ -321,7 +324,8 @@ int hvm_load(struct domain *d, hvm_domain_context_t *h)
+         {
+             printk(XENLOG_G_ERR "HVM%d restore: unknown entry typecode %u\n",
+                    d->domain_id, desc->typecode);
+-            return -EINVAL;
++            rc = -EINVAL;
++            goto out;
+         }
+ 
+         /* Load the entry */
+@@ -332,12 +336,18 @@ int hvm_load(struct domain *d, hvm_domain_context_t *h)
+         {
+             printk(XENLOG_G_ERR "HVM%d restore: failed to load entry %u/%u rc %d\n",
+                    d->domain_id, desc->typecode, desc->instance, rc);
+-            return rc;
++            goto out;
+         }
+         process_pending_softirqs();
+     }
+ 
+     /* Not reached */
++    ASSERT_UNREACHABLE();
++
++ out:
++    this_cpu(memory_type_changed_ignore) = false;
++    memory_type_changed(d);
++    return rc;
+ }
+ 
+ int _hvm_init_entry(struct hvm_domain_context *h, uint16_t tc, uint16_t inst,
+diff --git a/xen/arch/x86/include/asm/mtrr.h b/xen/arch/x86/include/asm/mtrr.h
+index 14246e3387..5a41a390d0 100644
+--- a/xen/arch/x86/include/asm/mtrr.h
++++ b/xen/arch/x86/include/asm/mtrr.h
+@@ -48,6 +48,15 @@ struct mtrr_state {
+ };
+ extern struct mtrr_state mtrr_state;
+ 
++/*
++ * The purpose of the memory_type_changed_ignore cpu flag is to
++ * avoid unecessary cache flushes when doing multiple memory type
++ * operations that may flush the cache. Code can set this flag, do
++ * several memory type operations, clear the flag and then call
++ * memory_type_changed() to flush the cache at the end.
++ */
++DECLARE_PER_CPU(bool, memory_type_changed_ignore);
++
+ extern void cf_check mtrr_save_fixed_ranges(void *);
+ extern void mtrr_save_state(void);
+ extern int mtrr_add(unsigned long base, unsigned long size,
+-- 
+2.43.0
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -154,6 +154,7 @@ _feature_patches=(
 	"0005-x86-hpet-Pre-cleanup.patch"
 	"0006-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch"
 	"0007-x86-hpet-Post-cleanup.patch"
+	"0011-x86-HVM-Avoid-cache-flush-operations-during-hvm_load.patch"
 )
 
 
@@ -242,6 +243,7 @@ _feature_patch_sums=(
 	"129fa7ec5930e98a99c15f1efdc0c23ea508492d95095bf1ed84e2a98b131fc0e8523acafe15e44c257ca6d1217a291e30057533daeb78826c368336d2fd0e61" # 0005-x86-hpet-Pre-cleanup.patch
 	"51e95193d3d2a27c9ad7e5fc24a73d88688b7183fee3c037b9f3e8e10ac97427ba869c5c1a5fc6004e5d3d41da66cc63a0c06fe3fd10d6ae4604a744a5d3d776" # 0006-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch
 	"1d016e8f8c0e6a76453e21fefb87949a12be24a48c84d1fdac67aea500e7a6b3721399fd8911f73ddfdfffad8831598a4afc8e207fde8a34a3b52e97c4e23478" # 0007-x86-hpet-Post-cleanup.patch
+	"cdb5e6347e58a39e4af8ab3ab8207f931ef36a1718b896a0262469cce1a4a45c912aa82731381e492c75d2597125e7c12585f3c88287dfb9d7696f93d2942f9f" # 0011-x86-HVM-Avoid-cache-flush-operations-during-hvm_load.patch
 )
 
 


### PR DESCRIPTION
Avoid cache flush operations during hvm_load. This reduces the time to restore an HVM guest with 32 vCPUs by about 5 seconds.