### PR TITLE
xen: Don't insert PCI device into xenstore for HVM guests

### DIFF
--- a/xen/0012-libxl-Don-t-insert-PCI-device-into-xenstore-for-HVM-.patch
+++ b/xen/0012-libxl-Don-t-insert-PCI-device-into-xenstore-for-HVM-.patch
@@ -1,0 +1,39 @@
+From 6ea72b56e23f05a7f2b421d2ffe1cae57b0d529c Mon Sep 17 00:00:00 2001
+From: Ross Lagerwall <ross.lagerwall@citrix.com>
+Date: Wed, 27 May 2015 10:04:00 +0100
+Subject: [PATCH 12/18] libxl: Don't insert PCI device into xenstore for HVM
+ guests
+
+When doing passthrough of a PCI device for an HVM guest, don't insert
+the device into xenstore, otherwise pciback attempts to use it which
+conflicts with QEMU.
+
+Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>
+---
+ tools/libs/light/libxl_pci.c | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/tools/libs/light/libxl_pci.c b/tools/libs/light/libxl_pci.c
+index 5f5f504bd2..2da9b9ae46 100644
+--- a/tools/libs/light/libxl_pci.c
++++ b/tools/libs/light/libxl_pci.c
+@@ -1416,6 +1416,7 @@ static void pci_add_dm_done(libxl__egc *egc,
+     STATE_AO_GC(pas->aodev->ao);
+     libxl_ctx *ctx = libxl__gc_owner(gc);
+     libxl_domid domid = pas->pci_domid;
++    libxl_domain_type type = libxl__domain_type(gc, domid);
+     char *sysfs_path;
+     FILE *f;
+     unsigned long long start, end, flags, size;
+@@ -1542,7 +1543,7 @@ out_no_irq:
+         }
+     }
+ 
+-    if (!libxl_get_stubdom_id(CTX, domid))
++    if (!libxl_get_stubdom_id(CTX, domid) && type == LIBXL_DOMAIN_TYPE_PV)
+         rc = libxl__device_pci_add_xenstore(gc, domid, pci, starting);
+     else
+         rc = 0;
+-- 
+2.43.0
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -154,6 +154,7 @@ _feature_patches=(
 	"0005-x86-hpet-Pre-cleanup.patch"
 	"0006-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch"
 	"0007-x86-hpet-Post-cleanup.patch"
+	"0012-libxl-Don-t-insert-PCI-device-into-xenstore-for-HVM-.patch"
 )
 
 
@@ -242,6 +243,7 @@ _feature_patch_sums=(
 	"129fa7ec5930e98a99c15f1efdc0c23ea508492d95095bf1ed84e2a98b131fc0e8523acafe15e44c257ca6d1217a291e30057533daeb78826c368336d2fd0e61" # 0005-x86-hpet-Pre-cleanup.patch
 	"51e95193d3d2a27c9ad7e5fc24a73d88688b7183fee3c037b9f3e8e10ac97427ba869c5c1a5fc6004e5d3d41da66cc63a0c06fe3fd10d6ae4604a744a5d3d776" # 0006-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch
 	"1d016e8f8c0e6a76453e21fefb87949a12be24a48c84d1fdac67aea500e7a6b3721399fd8911f73ddfdfffad8831598a4afc8e207fde8a34a3b52e97c4e23478" # 0007-x86-hpet-Post-cleanup.patch
+	"fe2cb471c4647274dbb6603e9a2ef87882ed8c2d0cd1d1dfddab234f26b5f86bff23af20a4223d35ea5ffe1fff3ad4e5be091249c599b21f835e3c0039b3fb8c" # 0012-libxl-Don-t-insert-PCI-device-into-xenstore-for-HVM-.patch
 )
 
 


### PR DESCRIPTION
Don't insert the passed through PCI device into xenstore to stop pciback from attempting to use it, which conflicts with QEMU.