### PR TITLE
xen: Don't idle scrub before microcode update

### DIFF
--- a/xen/0014-common-page_alloc-don-t-idle-scrub-before-microcode-.patch
+++ b/xen/0014-common-page_alloc-don-t-idle-scrub-before-microcode-.patch
@@ -1,0 +1,61 @@
+From ea10354e4152414573d52ce938bca353022fd6e0 Mon Sep 17 00:00:00 2001
+From: Sergey Dyasli <sergey.dyasli@citrix.com>
+Date: Mon, 26 Nov 2018 09:41:19 +0000
+Subject: [PATCH 14/18] common/page_alloc: don't idle scrub before microcode
+ update
+
+Signed-off-by: Sergey Dyasli <sergey.dyasli@citrix.com>
+---
+ xen/arch/x86/setup.c     | 4 ++++
+ xen/common/page_alloc.c  | 7 +++++++
+ xen/include/xen/kernel.h | 1 +
+ 3 files changed, 12 insertions(+)
+
+diff --git a/xen/arch/x86/setup.c b/xen/arch/x86/setup.c
+index a3d3f797bb..3ebbd0f2b1 100644
+--- a/xen/arch/x86/setup.c
++++ b/xen/arch/x86/setup.c
+@@ -1979,6 +1979,10 @@ void __init noreturn __start_xen(unsigned long mbi_p)
+         }
+     }
+ 
++    system_state = SYS_STATE_smp_booted;
++    /* Wake up secondary CPUs to start idle memory scrubbing */
++    smp_send_event_check_mask(&cpu_online_map);
++
+     printk("Brought up %ld CPUs\n", (long)num_online_cpus());
+     if ( num_parked )
+         printk(XENLOG_INFO "Parked %u CPUs\n", num_parked);
+diff --git a/xen/common/page_alloc.c b/xen/common/page_alloc.c
+index 9b5df74fdd..e78199cd89 100644
+--- a/xen/common/page_alloc.c
++++ b/xen/common/page_alloc.c
+@@ -1283,6 +1283,13 @@ bool scrub_free_pages(void)
+     nodeid_t node;
+     unsigned int cnt = 0;
+ 
++    /*
++     * Don't start scrubbing until all secondary CPUs have booted and
++     * updated their microcode.
++     */
++    if ( system_state < SYS_STATE_smp_booted )
++        return false;
++
+     node = node_to_scrub(true);
+     if ( node == NUMA_NO_NODE )
+         return false;
+diff --git a/xen/include/xen/kernel.h b/xen/include/xen/kernel.h
+index 46b3c9c026..16d49d9e7e 100644
+--- a/xen/include/xen/kernel.h
++++ b/xen/include/xen/kernel.h
+@@ -97,6 +97,7 @@ extern enum system_state {
+     SYS_STATE_early_boot,
+     SYS_STATE_boot,
+     SYS_STATE_smp_boot,
++    SYS_STATE_smp_booted,
+     SYS_STATE_active,
+     SYS_STATE_suspend,
+     SYS_STATE_resume
+-- 
+2.43.0
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -154,6 +154,7 @@ _feature_patches=(
 	"0005-x86-hpet-Pre-cleanup.patch"
 	"0006-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch"
 	"0007-x86-hpet-Post-cleanup.patch"
+	"0014-common-page_alloc-don-t-idle-scrub-before-microcode-.patch"
 )
 
 
@@ -242,6 +243,7 @@ _feature_patch_sums=(
 	"129fa7ec5930e98a99c15f1efdc0c23ea508492d95095bf1ed84e2a98b131fc0e8523acafe15e44c257ca6d1217a291e30057533daeb78826c368336d2fd0e61" # 0005-x86-hpet-Pre-cleanup.patch
 	"51e95193d3d2a27c9ad7e5fc24a73d88688b7183fee3c037b9f3e8e10ac97427ba869c5c1a5fc6004e5d3d41da66cc63a0c06fe3fd10d6ae4604a744a5d3d776" # 0006-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch
 	"1d016e8f8c0e6a76453e21fefb87949a12be24a48c84d1fdac67aea500e7a6b3721399fd8911f73ddfdfffad8831598a4afc8e207fde8a34a3b52e97c4e23478" # 0007-x86-hpet-Post-cleanup.patch
+	"0e40eb04f0182b15630bab969b0da07c3e91d3b5f126e7b8eed630c9d5ef32de48b3219e0ab5d117347702673a95d5a1d0b9c85f673c3e041c506a22e633c926" # 0014-common-page_alloc-don-t-idle-scrub-before-microcode-.patch
 )
 
 


### PR DESCRIPTION
Make sure all secondary CPUs have been booted and applied their microcode before doing memory scrubbing. This avoids potential hypothetical bugs where the scrubbing doesn't actually work properly because of microcode fixes not yet being applied to the CPUs.