### PR TITLE
xen: Hide detailed information from domU

### DIFF
--- a/xen/0017-xsm-hide-detailed-Xen-version-from-unprivileged-gues.patch
+++ b/xen/0017-xsm-hide-detailed-Xen-version-from-unprivileged-gues.patch
@@ -1,0 +1,60 @@
+From 3dc20ddec5191ed4ce0ed4b295678dd1b73237b4 Mon Sep 17 00:00:00 2001
+From: Sergey Dyasli <sergey.dyasli@citrix.com>
+Date: Tue, 23 Jul 2019 16:49:29 +0100
+Subject: [PATCH 17/18] xsm: hide detailed Xen version from unprivileged guests
+
+These subops leak information into guests which they have no buisness
+knowning.  Return empty strings instead.
+
+Signed-off-by: Sergey Dyasli <sergey.dyasli@citrix.com>
+---
+ xen/common/version.c    |  2 +-
+ xen/include/xsm/dummy.h | 15 +++++++++++----
+ 2 files changed, 12 insertions(+), 5 deletions(-)
+
+diff --git a/xen/common/version.c b/xen/common/version.c
+index d320135208..7937573a3f 100644
+--- a/xen/common/version.c
++++ b/xen/common/version.c
+@@ -67,7 +67,7 @@ const char *xen_banner(void)
+ 
+ const char *xen_deny(void)
+ {
+-    return "<denied>";
++    return "";
+ }
+ 
+ static const char build_info[] =
+diff --git a/xen/include/xsm/dummy.h b/xen/include/xsm/dummy.h
+index 8671af1ba4..f80d486531 100644
+--- a/xen/include/xsm/dummy.h
++++ b/xen/include/xsm/dummy.h
+@@ -827,14 +827,21 @@ static XSM_INLINE int cf_check xsm_xen_version(XSM_DEFAULT_ARG uint32_t op)
+         /* These sub-ops ignore the permission checks and return data. */
+         block_speculation();
+         return 0;
+-    case XENVER_extraversion:
+-    case XENVER_compile_info:
+-    case XENVER_capabilities:
+-    case XENVER_changeset:
++
+     case XENVER_pagesize:
+     case XENVER_guest_handle:
+         /* These MUST always be accessible to any guest by default. */
+         return xsm_default_action(XSM_HOOK, current->domain, NULL);
++
++    case XENVER_extraversion:
++    case XENVER_compile_info:
++    case XENVER_capabilities:
++    case XENVER_changeset:
++        if ( IS_ENABLED(CONFIG_DEBUG) )
++            /* Expose information to guests only in debug builds. */
++            return xsm_default_action(XSM_HOOK, current->domain, NULL);
++
++        /* fallthrough */
+     default:
+         return xsm_default_action(XSM_PRIV, current->domain, NULL);
+     }
+-- 
+2.43.0
+

--- a/xen/PKGBUILD
+++ b/xen/PKGBUILD
@@ -154,6 +154,7 @@ _feature_patches=(
 	"0005-x86-hpet-Pre-cleanup.patch"
 	"0006-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch"
 	"0007-x86-hpet-Post-cleanup.patch"
+	"0017-xsm-hide-detailed-Xen-version-from-unprivileged-gues.patch"
 )
 
 
@@ -242,6 +243,7 @@ _feature_patch_sums=(
 	"129fa7ec5930e98a99c15f1efdc0c23ea508492d95095bf1ed84e2a98b131fc0e8523acafe15e44c257ca6d1217a291e30057533daeb78826c368336d2fd0e61" # 0005-x86-hpet-Pre-cleanup.patch
 	"51e95193d3d2a27c9ad7e5fc24a73d88688b7183fee3c037b9f3e8e10ac97427ba869c5c1a5fc6004e5d3d41da66cc63a0c06fe3fd10d6ae4604a744a5d3d776" # 0006-x86-hpet-Use-singe-apic-vector-rather-than-irq_descs.patch
 	"1d016e8f8c0e6a76453e21fefb87949a12be24a48c84d1fdac67aea500e7a6b3721399fd8911f73ddfdfffad8831598a4afc8e207fde8a34a3b52e97c4e23478" # 0007-x86-hpet-Post-cleanup.patch
+	"8bb05599893aa1b698279d7f15b56bbee64283e81bf769148da11f975ade93dd1fd7a9ab9c25df723d21974c64c70362d76e003ba415ad654cbc240e2dbe78c2" # 0017-xsm-hide-detailed-Xen-version-from-unprivileged-gues.patch
 )
 
 


### PR DESCRIPTION
Guest domains have no business knowing the Xen version being run on the system, as this is basically painting a target on the server's back. Return empty strings instead.